### PR TITLE
[CDS-12] Qt version verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,7 @@ set(CMAKE_CXX_STANDARD 14)
 option(WITH_COVERAGE "Build with coverage" OFF)
 option(WITH_TESTS "Build with test" ON)
 
-set(QT_REQUIRED_VERSION "5.8" CACHE INTERNAL "Minimal required Qt version")
-
+set(QT_REQUIRED_VERSION "5.8")
 find_package(Qt5Core ${QT_REQUIRED_VERSION} REQUIRED)
 find_package(Qt5SerialBus ${QT_REQUIRED_VERSION} REQUIRED)
 find_package(Qt5Widgets ${QT_REQUIRED_VERSION} REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 14)
 option(WITH_COVERAGE "Build with coverage" OFF)
 option(WITH_TESTS "Build with test" ON)
 
-find_package(Qt5Core REQUIRED)
+find_package(Qt5Core 5.8 REQUIRED)
 find_package(Qt5SerialBus REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,11 @@ set(CMAKE_CXX_STANDARD 14)
 option(WITH_COVERAGE "Build with coverage" OFF)
 option(WITH_TESTS "Build with test" ON)
 
-find_package(Qt5Core 5.8 REQUIRED)
-find_package(Qt5SerialBus REQUIRED)
-find_package(Qt5Widgets REQUIRED)
+set(QT_REQUIRED_VERSION "5.8" CACHE INTERNAL "Minimal required Qt version")
+
+find_package(Qt5Core ${QT_REQUIRED_VERSION} REQUIRED)
+find_package(Qt5SerialBus ${QT_REQUIRED_VERSION} REQUIRED)
+find_package(Qt5Widgets ${QT_REQUIRED_VERSION} REQUIRED)
 
 set_property(TARGET Qt5::SerialBus PROPERTY INTERFACE_COMPILE_FEATURES "")
 set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")


### PR DESCRIPTION
CMake will now issue an error message if the version of Qt used for the build is
older than 5.8.