### PR TITLE
CDS-33 Drag/Drop columns / CDS-34 Sort columns

### DIFF
--- a/src/components/canrawview/canrawview.ui
+++ b/src/components/canrawview/canrawview.ui
@@ -69,6 +69,9 @@
      <property name="sizeAdjustPolicy">
       <enum>QAbstractScrollArea::AdjustToContents</enum>
      </property>
+     <property name="dragEnabled">
+      <bool>false</bool>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>

--- a/src/components/canrawview/canrawview.ui
+++ b/src/components/canrawview/canrawview.ui
@@ -73,13 +73,16 @@
       <bool>false</bool>
      </property>
      <property name="sortingEnabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
       <number>60</number>
      </attribute>
      <attribute name="horizontalHeaderMinimumSectionSize">
       <number>40</number>
+     </attribute>
+     <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+      <bool>true</bool>
      </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>

--- a/src/components/canrawview/canrawview.ui
+++ b/src/components/canrawview/canrawview.ui
@@ -65,7 +65,26 @@
     </layout>
    </item>
    <item>
-    <widget class="QTableView" name="tv"/>
+    <widget class="QTableView" name="tv">
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>60</number>
+     </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>40</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -31,6 +31,7 @@ public:
 
         tvModel.setHorizontalHeaderLabels({ "time", "id", "dir", "dlc", "data" });
         ui->tv->setModel(&tvModel);
+        ui->tv->horizontalHeader()->setSectionsMovable(true);
 
         connect(ui->pbClear, &QPushButton::pressed, this, &CanRawViewPrivate::clear);
         connect(ui->pbDockUndock, &QPushButton::pressed, this, &CanRawViewPrivate::dockUndock);

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -7,6 +7,8 @@
 #include <QtGui/QStandardItemModel>
 #include <QtSerialBus/QCanBusFrame>
 #include <memory>
+#include <QDebug>
+#include <QHeaderView>
 
 namespace Ui {
 class CanRawViewPrivate;
@@ -29,14 +31,11 @@ public:
 
         tvModel.setHorizontalHeaderLabels({ "time", "id", "dir", "dlc", "data" });
         ui->tv->setModel(&tvModel);
-        ui->tv->setColumnWidth(0, 36);
-        ui->tv->setColumnWidth(1, 92);
-        ui->tv->setColumnWidth(2, 27);
-        ui->tv->setColumnWidth(3, 25);
-        ui->tv->setColumnWidth(4, 178);
 
         connect(ui->pbClear, &QPushButton::pressed, this, &CanRawViewPrivate::clear);
         connect(ui->pbDockUndock, &QPushButton::pressed, this, &CanRawViewPrivate::dockUndock);
+        connect(&tvModel, &QAbstractItemModel::dataChanged, this, &CanRawViewPrivate::update);
+
     }
 
     ~CanRawViewPrivate() {}
@@ -82,6 +81,10 @@ private slots:
     {
         Q_Q(CanRawView);
         emit q->dockUndock();
+    }
+
+    void update()
+    {
     }
 };
 #endif // CANRAWVIEW_P_H

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -7,7 +7,7 @@
 #include <QtGui/QStandardItemModel>
 #include <QtSerialBus/QCanBusFrame>
 #include <memory>
-#include <QDebug>
+#include <iostream>
 #include <QHeaderView>
 
 namespace Ui {
@@ -29,13 +29,16 @@ public:
     {
         ui->setupUi(this);
 
-        tvModel.setHorizontalHeaderLabels({ "time", "id", "dir", "dlc", "data" });
+        tvModel.setHorizontalHeaderLabels({ "rowID", "time", "id", "dir", "dlc", "data" });
         ui->tv->setModel(&tvModel);
         ui->tv->horizontalHeader()->setSectionsMovable(true);
+        //ui->tv->setColumnHidden(0, true);
 
         connect(ui->pbClear, &QPushButton::pressed, this, &CanRawViewPrivate::clear);
         connect(ui->pbDockUndock, &QPushButton::pressed, this, &CanRawViewPrivate::dockUndock);
-        connect(&tvModel, &QAbstractItemModel::dataChanged, this, &CanRawViewPrivate::update);
+
+        connect(ui->tv->horizontalHeader(), &QHeaderView::sectionClicked, [=]( const int &logicalIndex ) { sort( logicalIndex, clickedIndexes ); });
+        connect(&tvModel, &QAbstractItemModel::rowsInserted, [=]() { update( clickedIndexes ); });
 
     }
 
@@ -52,8 +55,10 @@ public:
         for (int ii = payHex.size(); ii >= 2; ii -= 2) {
             payHex.insert(ii, ' ');
         }
-
+        
+        static int rowID = 0;
         QList<QStandardItem*> list;
+        list.append(new QStandardItem(QString::number(rowID++)));
         list.append(new QStandardItem(QString::number((double)timer->elapsed() / 1000, 'f', 2)));
         list.append(new QStandardItem("0x" + QString::number(frame.frameId(), 16)));
         list.append(new QStandardItem(direction));
@@ -71,6 +76,7 @@ public:
     std::unique_ptr<QElapsedTimer> timer;
     QStandardItemModel tvModel;
     bool simStarted;
+    QList<int> clickedIndexes = {0,0,0};
 
 private:
     CanRawView* q_ptr;
@@ -84,8 +90,30 @@ private slots:
         emit q->dockUndock();
     }
 
-    void update()
+    void update(QList<int> &clickedIndexes)
     {
+    }
+
+    void sort(const int currentIndex, QList<int> &clickedIndexes)
+    {
+        clickedIndexes.removeFirst();
+        clickedIndexes.append(currentIndex);
+
+        if ((clickedIndexes[2] == clickedIndexes[1]) && (clickedIndexes[1] == clickedIndexes[0]))
+        {
+            ui->tv->sortByColumn(0,Qt::AscendingOrder);
+            clickedIndexes = {0,0,0};
+        }
+        else if (clickedIndexes[2] == clickedIndexes[1])
+        {
+            ui->tv->sortByColumn(currentIndex,Qt::DescendingOrder);
+            ui->tv->horizontalHeader()->setSortIndicator(currentIndex,Qt::DescendingOrder);
+        }
+        else
+        {
+            ui->tv->sortByColumn(currentIndex,Qt::AscendingOrder);
+            ui->tv->horizontalHeader()->setSortIndicator(currentIndex,Qt::AscendingOrder);
+        }
     }
 };
 #endif // CANRAWVIEW_P_H


### PR DESCRIPTION
CDS-33 is completed. You can drag/drop columns. I added property setSectionsMovable(true) in code, since I could't find this property in ui directly. 

CDS-34: sorting is implemented. What need to be done is create a tri-state sorting model, but I already created a seperate sub-task for this.

I also created a connection and empty slot update(), which is supposed to refresh QTableView when data in model changes. It should trigger functions to sort column based on given clicked index and resize column widths to content, but I think it should be done after tri-state sorting is dealt with.