### PR TITLE
Rename setters so they actually have "set" in their name

### DIFF
--- a/src/components/candevice/candevice.cpp
+++ b/src/components/candevice/candevice.cpp
@@ -10,9 +10,7 @@ CanDevice::CanDevice(CanFactoryInterface& factory)
 {
 }
 
-CanDevice::~CanDevice()
-{
-}
+CanDevice::~CanDevice() {}
 
 bool CanDevice::init(const QString& backend, const QString& interface)
 {
@@ -27,9 +25,9 @@ bool CanDevice::init(const QString& backend, const QString& interface)
         return false;
     }
 
-    d->canDevice->framesWritten(std::bind(&CanDevice::framesWritten, this, std::placeholders::_1));
-    d->canDevice->framesReceived(std::bind(&CanDevice::framesReceived, this));
-    d->canDevice->errorOccurred(std::bind(&CanDevice::errorOccurred, this, std::placeholders::_1));
+    d->canDevice->setFramesWrittenCbk(std::bind(&CanDevice::framesWritten, this, std::placeholders::_1));
+    d->canDevice->setFramesReceivedCbk(std::bind(&CanDevice::framesReceived, this));
+    d->canDevice->setErrorOccurredCbk(std::bind(&CanDevice::errorOccurred, this, std::placeholders::_1));
 
     // connect
 
@@ -61,12 +59,11 @@ bool CanDevice::start()
 {
     Q_D(CanDevice);
 
-    if(!d->canDevice) {
+    if (!d->canDevice) {
         return false;
     }
 
     return d->canDevice->connectDevice();
-
 }
 
 void CanDevice::framesReceived()

--- a/src/components/candevice/candeviceinterface.hpp
+++ b/src/components/candevice/candeviceinterface.hpp
@@ -1,9 +1,9 @@
 #ifndef CANDEVICEINTERFACE_HPP_DNXOI7PW
 #define CANDEVICEINTERFACE_HPP_DNXOI7PW
 
-#include <functional>
 #include <QtCore/QtGlobal>
 #include <QtSerialBus/QCanBusFrame>
+#include <functional>
 
 struct CanDeviceInterface {
     virtual ~CanDeviceInterface() {}
@@ -12,9 +12,9 @@ struct CanDeviceInterface {
     typedef std::function<void()> framesReceived_t;
     typedef std::function<void(int)> errorOccurred_t;
 
-    virtual void framesWritten(const framesWritten_t& cb) = 0;
-    virtual void framesReceived(const framesReceived_t& cb) = 0;
-    virtual void errorOccurred(const errorOccurred_t& cb) = 0;
+    virtual void setFramesWrittenCbk(const framesWritten_t& cb) = 0;
+    virtual void setFramesReceivedCbk(const framesReceived_t& cb) = 0;
+    virtual void setErrorOccurredCbk(const errorOccurred_t& cb) = 0;
 
     virtual bool writeFrame(const QCanBusFrame& frame) = 0;
     virtual bool connectDevice() = 0;

--- a/src/components/candevice/candeviceqt.hpp
+++ b/src/components/candevice/candeviceqt.hpp
@@ -15,17 +15,17 @@ struct CanDeviceQt : public CanDeviceInterface {
         }
     }
 
-    virtual void framesWritten(const framesWritten_t& cb) override
+    virtual void setFramesWrittenCbk(const framesWritten_t& cb) override
     {
         QObject::connect(_device, &QCanBusDevice::framesWritten, cb);
     }
 
-    virtual void framesReceived(const framesReceived_t& cb) override
+    virtual void setFramesReceivedCbk(const framesReceived_t& cb) override
     {
         QObject::connect(_device, &QCanBusDevice::framesReceived, cb);
     }
 
-    virtual void errorOccurred(const errorOccurred_t& cb) override
+    virtual void setErrorOccurredCbk(const errorOccurred_t& cb) override
     {
         QObject::connect(_device, &QCanBusDevice::errorOccurred, cb);
     }

--- a/tests/candevicetest.cpp
+++ b/tests/candevicetest.cpp
@@ -10,8 +10,8 @@
 std::shared_ptr<spdlog::logger> kDefaultLogger;
 
 #include <QSignalSpy>
-//needed for QSignalSpy cause according to qtbug 49623 comments
-//automatic detection of types is "flawed" in moc
+// needed for QSignalSpy cause according to qtbug 49623 comments
+// automatic detection of types is "flawed" in moc
 Q_DECLARE_METATYPE(QCanBusFrame);
 
 TEST_CASE("Initialization failed", "[candevice]")
@@ -30,9 +30,9 @@ TEST_CASE("Initialization succedded", "[candevice]")
     fakeit::Mock<CanDeviceInterface> deviceMock;
 
     Fake(Dtor(deviceMock));
-    When(Method(deviceMock, framesWritten)).Do([](const auto& cb) { cb(100); });
-    Fake(Method(deviceMock, framesReceived));
-    Fake(Method(deviceMock, errorOccurred));
+    When(Method(deviceMock, setFramesWrittenCbk)).Do([](const auto& cb) { cb(100); });
+    Fake(Method(deviceMock, setFramesReceivedCbk));
+    Fake(Method(deviceMock, setErrorOccurredCbk));
 
     fakeit::When(Method(factoryMock, create)).Return(&(deviceMock.get()));
     CanDevice canDevice{ factoryMock.get() };
@@ -57,9 +57,9 @@ TEST_CASE("Start failed - could not connect to device", "[candevice]")
     Mock<CanDeviceInterface> deviceMock;
 
     Fake(Dtor(deviceMock));
-    Fake(Method(deviceMock, framesWritten));
-    Fake(Method(deviceMock, framesReceived));
-    Fake(Method(deviceMock, errorOccurred));
+    Fake(Method(deviceMock, setFramesWrittenCbk));
+    Fake(Method(deviceMock, setFramesReceivedCbk));
+    Fake(Method(deviceMock, setErrorOccurredCbk));
     When(Method(deviceMock, connectDevice)).Return(false);
 
     When(Method(factoryMock, create)).Return(&(deviceMock.get()));
@@ -75,9 +75,9 @@ TEST_CASE("Start succeeded", "[candevice]")
     Mock<CanDeviceInterface> deviceMock;
 
     Fake(Dtor(deviceMock));
-    Fake(Method(deviceMock, framesWritten));
-    Fake(Method(deviceMock, framesReceived));
-    Fake(Method(deviceMock, errorOccurred));
+    Fake(Method(deviceMock, setFramesWrittenCbk));
+    Fake(Method(deviceMock, setFramesReceivedCbk));
+    Fake(Method(deviceMock, setErrorOccurredCbk));
     When(Method(deviceMock, connectDevice)).Return(true);
 
     When(Method(factoryMock, create)).Return(&(deviceMock.get()));
@@ -93,12 +93,11 @@ TEST_CASE("sendFrame results in frameSent being emitted and writeFrame being cal
     Mock<CanDeviceInterface> deviceMock;
 
     Fake(Dtor(deviceMock));
-    Fake(Method(deviceMock, framesWritten));
-    Fake(Method(deviceMock, framesReceived));
-    Fake(Method(deviceMock, errorOccurred));
+    Fake(Method(deviceMock, setFramesWrittenCbk));
+    Fake(Method(deviceMock, setFramesReceivedCbk));
+    Fake(Method(deviceMock, setErrorOccurredCbk));
     Fake(Method(deviceMock, connectDevice));
     When(Method(deviceMock, writeFrame)).Return(false);
-    qRegisterMetaType<QCanBusFrame>();    //required by QSignalSpy
     QCanBusFrame testFrame;
     testFrame.setFrameId(123);
 
@@ -119,12 +118,11 @@ TEST_CASE("sendFrame, writeframe returns true, no signal emitted", "[candevice]"
     Mock<CanDeviceInterface> deviceMock;
 
     Fake(Dtor(deviceMock));
-    Fake(Method(deviceMock, framesWritten));
-    Fake(Method(deviceMock, framesReceived));
-    Fake(Method(deviceMock, errorOccurred));
+    Fake(Method(deviceMock, setFramesWrittenCbk));
+    Fake(Method(deviceMock, setFramesReceivedCbk));
+    Fake(Method(deviceMock, setErrorOccurredCbk));
     Fake(Method(deviceMock, connectDevice));
     When(Method(deviceMock, writeFrame)).Return(true);
-    qRegisterMetaType<QCanBusFrame>();    //required by QSignalSpy
     QCanBusFrame testFrame;
 
     When(Method(factoryMock, create)).Return(&(deviceMock.get()));
@@ -140,7 +138,6 @@ TEST_CASE("sendFrame, no device availablie, frameSent is not emitted", "[candevi
     using namespace fakeit;
     Mock<CanFactoryInterface> factoryMock;
 
-    qRegisterMetaType<QCanBusFrame>();    //required by QSignalSpy
     QCanBusFrame testFrame;
 
     When(Method(factoryMock, create)).Return(nullptr);
@@ -160,5 +157,6 @@ int main(int argc, char* argv[])
         kDefaultLogger->set_level(spdlog::level::debug);
     }
     cds_debug("Staring unit tests");
+    qRegisterMetaType<QCanBusFrame>(); // required by QSignalSpy
     return Catch::Session().run(argc, argv);
 }


### PR DESCRIPTION
CanDeviceInterface's virtual methods are only used for setting the callback
functions which are actually called later on by the interface's implementation.
Meanwhile, their current names suggest as if they were the callback functions
themselves and their naming is similar to the one found in Qt's signals.

Since they are actually only setters for the said callbacks, add "set" to the
names of the functions to avoid confusion.

As a bonus, run clang-format on the affected files and move qRegisterMetaType in
candevicetest.cpp to main, since it can be registered for all the test cases
without causing any trouble.