### PR TITLE
Sorting - bug fix

### DIFF
--- a/src/components/canrawview/canrawview.ui
+++ b/src/components/canrawview/canrawview.ui
@@ -69,6 +69,9 @@
      <property name="sizeAdjustPolicy">
       <enum>QAbstractScrollArea::AdjustToContents</enum>
      </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="dragEnabled">
       <bool>false</bool>
      </property>
@@ -88,6 +91,9 @@
       <bool>true</bool>
      </attribute>
      <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderShowSortIndicator" stdset="0">
       <bool>false</bool>
      </attribute>
     </widget>

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -29,10 +29,11 @@ public:
     {
         ui->setupUi(this);
 
-        tvModel.setHorizontalHeaderLabels({ "rowID", "time", "id", "dir", "dlc", "data" });
+        tvModel.setHorizontalHeaderLabels({ "rowID", "timeDouble", "time", "id", "dir", "dlc", "data" });
         ui->tv->setModel(&tvModel);
         ui->tv->horizontalHeader()->setSectionsMovable(true);
-        //ui->tv->setColumnHidden(0, true);
+        ui->tv->setColumnHidden(0, true);
+        ui->tv->setColumnHidden(1, true);
 
         connect(ui->pbClear, &QPushButton::pressed, this, &CanRawViewPrivate::clear);
         connect(ui->pbDockUndock, &QPushButton::pressed, this, &CanRawViewPrivate::dockUndock);
@@ -57,17 +58,18 @@ public:
         }
         
         static int rowID = 0;
-        QList<QVariant> qvlist;
+        QList<QVariant> qvList;
         QList<QStandardItem*> list;
 
-        qvlist.append(rowID++);
-        qvlist.append(QString::number((double)timer->elapsed() / 1000, 'f', 2).toDouble());
-        qvlist.append(QString("0x" + QString::number(frame.frameId(), 16)));
-        qvlist.append(direction);
-        qvlist.append(QString::number(frame.payload().size()).toInt());
-        qvlist.append(QString::fromUtf8(payHex.data(), payHex.size()).toInt());
+        qvList.append(rowID++);
+        qvList.append(QString::number((double)timer->elapsed() / 1000, 'f', 2).toDouble());
+        qvList.append(QString::number((double)timer->elapsed() / 1000, 'f', 2));
+        qvList.append(QString("0x" + QString::number(frame.frameId(), 16)));
+        qvList.append(direction);
+        qvList.append(QString::number(frame.payload().size()).toInt());
+        qvList.append(QString::fromUtf8(payHex.data(), payHex.size()).toInt());
 
-        for (QVariant qvitem : qvlist)
+        for (QVariant qvitem : qvList)
         {
             QStandardItem* item = new QStandardItem();
             item->setData(qvitem,Qt::EditRole);
@@ -106,7 +108,11 @@ private slots:
     void sort(const int currentIndex, QList<int> &clickedIndexes)
     {
         clickedIndexes.removeFirst();
-        clickedIndexes.append(currentIndex);
+
+        if (currentIndex == 2)
+            clickedIndexes.append(1);
+        else
+            clickedIndexes.append(currentIndex);
 
         if ((clickedIndexes[2] == clickedIndexes[1]) && (clickedIndexes[1] == clickedIndexes[0]))
         {
@@ -115,12 +121,12 @@ private slots:
         }
         else if (clickedIndexes[2] == clickedIndexes[1])
         {
-            ui->tv->sortByColumn(currentIndex,Qt::DescendingOrder);
+            ui->tv->sortByColumn(clickedIndexes[2],Qt::DescendingOrder);
             ui->tv->horizontalHeader()->setSortIndicator(currentIndex,Qt::DescendingOrder);
         }
         else
         {
-            ui->tv->sortByColumn(currentIndex,Qt::AscendingOrder);
+            ui->tv->sortByColumn(clickedIndexes[2],Qt::AscendingOrder);
             ui->tv->horizontalHeader()->setSortIndicator(currentIndex,Qt::AscendingOrder);
         }
     }

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -7,8 +7,6 @@
 #include <QtCore/QElapsedTimer>
 #include <QtGui/QStandardItemModel>
 #include <QtSerialBus/QCanBusFrame>
-#include <iostream>
-#include <memory>
 
 namespace Ui {
 class CanRawViewPrivate;
@@ -40,9 +38,8 @@ public:
         connect(ui->pbClear, &QPushButton::pressed, this, &CanRawViewPrivate::clear);
         connect(ui->pbDockUndock, &QPushButton::pressed, this, &CanRawViewPrivate::dockUndock);
 
-        connect(ui->tv->horizontalHeader(), &QHeaderView::sectionClicked,
-            [=](const int& logicalIndex) { sort(logicalIndex); });
-        connect(&tvModel, &QAbstractItemModel::rowsInserted, [=]() { update(); });
+        connect(
+            ui->tv->horizontalHeader(), &QHeaderView::sectionClicked, [=](int logicalIndex) { sort(logicalIndex); });
     }
 
     ~CanRawViewPrivate() {}
@@ -59,7 +56,6 @@ public:
             payHex.insert(ii, ' ');
         }
 
-        static int rowID = 0;
         QList<QVariant> qvList;
         QList<QStandardItem*> list;
 
@@ -92,6 +88,8 @@ public:
 
 private:
     CanRawView* q_ptr;
+    int prevIndex = 0;
+    int rowID = 0;
 
 private slots:
     void clear() {}
@@ -102,13 +100,10 @@ private slots:
         emit q->dockUndock();
     }
 
-    void update() {}
-
     void sort(const int clickedIndex)
     {
         int currentSortOrder = ui->tv->horizontalHeader()->sortIndicatorOrder();
         int sortIndex = clickedIndex;
-        static int prevIndex = 0;
 
         if ((ui->tv->model()->headerData(clickedIndex, Qt::Horizontal).toString() == "time")
             || (ui->tv->model()->headerData(clickedIndex, Qt::Horizontal).toString() == "id")) {

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <iostream>
 #include <QHeaderView>
-
+using namespace std;
 namespace Ui {
 class CanRawViewPrivate;
 }
@@ -57,13 +57,22 @@ public:
         }
         
         static int rowID = 0;
+        QList<QVariant> qvlist;
         QList<QStandardItem*> list;
-        list.append(new QStandardItem(QString::number(rowID++)));
-        list.append(new QStandardItem(QString::number((double)timer->elapsed() / 1000, 'f', 2)));
-        list.append(new QStandardItem("0x" + QString::number(frame.frameId(), 16)));
-        list.append(new QStandardItem(direction));
-        list.append(new QStandardItem(QString::number(frame.payload().size())));
-        list.append(new QStandardItem(QString::fromUtf8(payHex.data(), payHex.size())));
+
+        qvlist.append(rowID++);
+        qvlist.append(QString::number((double)timer->elapsed() / 1000, 'f', 2).toDouble());
+        qvlist.append(QString("0x" + QString::number(frame.frameId(), 16)));
+        qvlist.append(direction);
+        qvlist.append(QString::number(frame.payload().size()).toInt());
+        qvlist.append(QString::fromUtf8(payHex.data(), payHex.size()).toInt());
+
+        for (QVariant qvitem : qvlist)
+        {
+            QStandardItem* item = new QStandardItem();
+            item->setData(qvitem,Qt::EditRole);
+            list.append(item);
+        }
 
         tvModel.appendRow(list);
 


### PR DESCRIPTION
Added QVariant list which holds info about data type (QStandardItemModel seems to accept only QStrings and QVariants). Sorting is now based on data type (whether it was string or int or double). 

There was a problem with time display, as it was properly sorted, but trailing zeros were omitted during display,so I added another column (hidden) which holds time data. Now we have two time columns - one holds info as a double, another as a string. First is used to sort, another one to display data. 

I also set rowID column to be hidden. 