### PR TITLE
CDS-68 Unit Tests

### DIFF
--- a/src/components/candevice/candevicemodel.cpp
+++ b/src/components/candevice/candevicemodel.cpp
@@ -1,11 +1,7 @@
 #include "candevicemodel.h"
-#include <QtCore/QDir>
-#include <QtCore/QEvent>
 
 #include "log.hpp"
 #include <assert.h>
-
-#include <QtWidgets/QFileDialog>
 
 #include "datamodeltypes/candevicedata.h"
 #include <nodes/DataModelRegistry>
@@ -22,6 +18,7 @@ CanDeviceModel::CanDeviceModel()
 
     connect(canDevice.get(), &CanDevice::frameSent, this, &CanDeviceModel::frameSent);
     connect(canDevice.get(), &CanDevice::frameReceived, this, &CanDeviceModel::frameReceived);
+    connect(this, &CanDeviceModel::sendFrame, canDevice.get(), &CanDevice::sendFrame);
 
     canDevice->init("socketcan", "can0"); // TODO
     canDevice->start();
@@ -69,7 +66,7 @@ void CanDeviceModel::setInData(std::shared_ptr<NodeData> nodeData, PortIndex)
     if (nodeData) {
         auto d = std::dynamic_pointer_cast<CanDeviceDataIn>(nodeData);
         assert(nullptr != d);
-        canDevice->sendFrame(d->frame());
+        emit sendFrame(d->frame());
     } else {
         cds_warn("Incorrect nodeData");
     }

--- a/src/components/candevice/candevicemodel.h
+++ b/src/components/candevice/candevicemodel.h
@@ -134,6 +134,9 @@ private:
     QCanBusFrame _frame;
 
     std::unique_ptr<CanDevice> canDevice;
+
+signals:
+    void sendFrame(const QCanBusFrame& frame);
 };
 
 #endif // CANDEVICEMODEL_H

--- a/src/components/canrawsender/canrawsendermodel.cpp
+++ b/src/components/canrawsender/canrawsendermodel.cpp
@@ -1,8 +1,5 @@
 #include "canrawsendermodel.h"
 #include "datamodeltypes/canrawsenderdata.h"
-#include <QtCore/QDir>
-#include <QtCore/QEvent>
-#include <QtWidgets/QFileDialog>
 #include <nodes/DataModelRegistry>
 
 CanRawSenderModel::CanRawSenderModel()
@@ -28,8 +25,6 @@ std::shared_ptr<NodeData> CanRawSenderModel::outData(PortIndex)
 {
     return std::make_shared<CanRawSenderDataOut>(_frame);
 }
-
-void CanRawSenderModel::setInData(std::shared_ptr<NodeData>, PortIndex) {}
 
 void CanRawSenderModel::sendFrame(const QCanBusFrame& frame)
 {

--- a/src/components/canrawsender/canrawsendermodel.h
+++ b/src/components/canrawsender/canrawsendermodel.h
@@ -87,7 +87,7 @@ public:
     *   @param  data on port
     *   @param  port id
     */
-    void setInData(std::shared_ptr<NodeData>, PortIndex) override;
+    void setInData(std::shared_ptr<NodeData>, PortIndex) override {};
 
     /**
     *   @brief  Used to get widget embedded in Node

--- a/src/components/canrawview/canrawviewmodel.cpp
+++ b/src/components/canrawview/canrawviewmodel.cpp
@@ -10,11 +10,12 @@ CanRawViewModel::CanRawViewModel()
     : label(new QLabel())
 {
     label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
-
     label->setFixedSize(75, 25);
-
     label->setAttribute(Qt::WA_TranslucentBackground);
+
     canRawView.setWindowTitle("CANrawView");
+    connect(this, &CanRawViewModel::frameSent, &canRawView, &CanRawView::frameSent);
+    connect(this, &CanRawViewModel::frameReceived, &canRawView, &CanRawView::frameReceived);
 }
 
 unsigned int CanRawViewModel::nPorts(PortType portType) const { return (PortType::In == portType) ? 1 : 0; }
@@ -29,9 +30,9 @@ void CanRawViewModel::setInData(std::shared_ptr<NodeData> nodeData, PortIndex)
         auto d = std::dynamic_pointer_cast<CanRawViewDataIn>(nodeData);
         assert(nullptr != d);
         if (d->direction() == Direction::TX) {
-            canRawView.frameSent(d->status(), d->frame());
+            emit frameSent(d->status(), d->frame());
         } else if (d->direction() == Direction::RX) {
-            canRawView.frameReceived(d->frame());
+            emit frameReceived(d->frame());
         } else {
             cds_warn("Incorrect direction");
         }

--- a/src/components/canrawview/canrawviewmodel.h
+++ b/src/components/canrawview/canrawviewmodel.h
@@ -106,6 +106,10 @@ private:
     QLabel* label;
     QCanBusFrame _frame;
     CanRawView viewWindow;
+
+signals:
+    void frameReceived(const QCanBusFrame& frame);
+    void frameSent(bool status, const QCanBusFrame& frame);
 };
 
 #endif // CANRAWVIEWMODEL_H

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -30,7 +30,6 @@ MainWindow::MainWindow(QWidget* parent)
     modelRegistry->registerModel<CanRawSenderModel>();
     modelRegistry->registerModel<CanRawViewModel>();
 
-    canRawSender = std::make_shared<CanRawSender>();
     graphScene = std::make_shared<QtNodes::FlowScene>(modelRegistry);
 
     connect(graphScene.get(), &QtNodes::FlowScene::nodeCreated, this, &MainWindow::nodeCreatedCallback);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,3 +15,18 @@ add_executable(canrawsender_test newlinemanager_test.cpp)
 target_link_libraries(canrawsender_test canrawsender Qt5::Core Qt5::SerialBus Qt5::Test cds-common)
 target_compile_options(canrawsender_test PRIVATE $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
 add_test( NAME CanRawSenderTest COMMAND canrawsender_test)
+
+add_executable(canrawsendermodel_test canrawsendermodel_test.cpp)
+target_link_libraries(canrawsendermodel_test canrawsender Qt5::Core Qt5::SerialBus Qt5::Test nodes cds-common)
+target_compile_options(canrawsendermodel_test PRIVATE $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
+add_test( NAME CanRawSenderModelTest COMMAND canrawsendermodel_test)
+
+add_executable(canrawviewmodel_test canrawviewmodel_test.cpp)
+target_link_libraries(canrawviewmodel_test canrawview Qt5::Core Qt5::SerialBus Qt5::Test nodes cds-common)
+target_compile_options(canrawviewmodel_test PRIVATE $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
+add_test( NAME CanRawViewModelTest COMMAND canrawviewmodel_test)
+
+add_executable(candevicemodel_test candevicemodel_test.cpp)
+target_link_libraries(candevicemodel_test candevice Qt5::Core Qt5::SerialBus Qt5::Test nodes cds-common)
+target_compile_options(candevicemodel_test PRIVATE $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
+add_test( NAME CanDeviceModelTest COMMAND candevicemodel_test)

--- a/tests/candevicemodel_test.cpp
+++ b/tests/candevicemodel_test.cpp
@@ -1,0 +1,92 @@
+#include <QtWidgets/QApplication>
+#include <candevice/candevicemodel.h>
+
+#define CATCH_CONFIG_RUNNER
+#include <fakeit.hpp>
+
+#include "log.hpp"
+std::shared_ptr<spdlog::logger> kDefaultLogger;
+
+#include <QSignalSpy>
+// needed for QSignalSpy cause according to qtbug 49623 comments
+// automatic detection of types is "flawed" in moc
+Q_DECLARE_METATYPE(QCanBusFrame);
+
+#include <datamodeltypes/candevicedata.h>
+
+TEST_CASE("Test basic functionality", "[candevice]")
+{
+    using namespace fakeit;
+    CanDeviceModel canDeviceModel;
+    CHECK(canDeviceModel.caption() == "CanDevice Node");
+    CHECK(canDeviceModel.name() == "CanDeviceModel");
+    CHECK(canDeviceModel.modelName() == "CAN device");
+    CHECK(canDeviceModel.resizable() == false);
+    CHECK(dynamic_cast<CanDeviceModel*>(canDeviceModel.clone().get()) != nullptr);
+    CHECK(dynamic_cast<QLabel*>(canDeviceModel.embeddedWidget()) != nullptr);
+}
+
+TEST_CASE("Port information", "[candevice]")
+{
+    CanDeviceModel canDeviceModel;
+    CanDeviceDataIn canDeviceDataIn;
+    CanDeviceDataOut canDeviceDataOut;
+    CHECK(canDeviceModel.nPorts(PortType::Out) == 1);
+    CHECK(canDeviceModel.nPorts(PortType::In) == 1);
+    CHECK(canDeviceModel.nPorts(PortType::None) == 0);
+    CHECK(canDeviceModel.dataType(PortType::Out, 0).id == canDeviceDataOut.type().id);
+    CHECK(canDeviceModel.dataType(PortType::Out, 0).name == canDeviceDataOut.type().name);
+    CHECK(canDeviceModel.dataType(PortType::In, 0).id == canDeviceDataIn.type().id);
+    CHECK(canDeviceModel.dataType(PortType::In, 0).name == canDeviceDataIn.type().name);
+}
+
+TEST_CASE("Calling frameReceived emits dataUpdated and outData returns that frame", "[candevice]")
+{
+    CanDeviceModel canDeviceModel;
+    QCanBusFrame testFrame;
+    testFrame.setFrameId(123);
+    QSignalSpy dataUpdatedSpy(&canDeviceModel, &CanDeviceModel::dataUpdated);
+    canDeviceModel.frameReceived(testFrame);
+
+    CHECK(dataUpdatedSpy.count() == 1);
+    CHECK(std::dynamic_pointer_cast<CanDeviceDataOut>(canDeviceModel.outData(0))->frame().frameId()
+        == testFrame.frameId());
+}
+
+TEST_CASE("Calling frameSent emits dataUpdated and outData returns that frame", "[candevice]")
+{
+    CanDeviceModel canDeviceModel;
+    QCanBusFrame testFrame;
+    testFrame.setFrameId(123);
+    QSignalSpy dataUpdatedSpy(&canDeviceModel, &CanDeviceModel::dataUpdated);
+    canDeviceModel.frameSent(true, testFrame);
+    CHECK(dataUpdatedSpy.count() == 1);
+    CHECK(std::dynamic_pointer_cast<CanDeviceDataOut>(canDeviceModel.outData(0))->frame().frameId()
+        == testFrame.frameId());
+}
+
+TEST_CASE("Calling setInData will result in sendFrame being emitted", "[candevice]")
+{
+    CanDeviceModel canDeviceModel;
+    QCanBusFrame testFrame;
+    testFrame.setFrameId(123);
+    auto canDeviceDataIn = std::make_shared<CanDeviceDataIn>(testFrame);
+    QSignalSpy sendFrameSpy(&canDeviceModel, &CanDeviceModel::sendFrame);
+
+    canDeviceModel.setInData(canDeviceDataIn, 0);
+    CHECK(sendFrameSpy.count() == 1);
+    CHECK(qvariant_cast<QCanBusFrame>(sendFrameSpy.takeFirst().at(0)).frameId() == testFrame.frameId());
+}
+
+int main(int argc, char* argv[])
+{
+    bool haveDebug = std::getenv("CDS_DEBUG") != nullptr;
+    kDefaultLogger = spdlog::stdout_color_mt("cds");
+    if (haveDebug) {
+        kDefaultLogger->set_level(spdlog::level::debug);
+    }
+    cds_debug("Staring unit tests");
+    qRegisterMetaType<QCanBusFrame>(); // required by QSignalSpy
+    QApplication a(argc, argv); // QApplication must exist when contructing QWidgets TODO check QTest
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/canrawsendermodel_test.cpp
+++ b/tests/canrawsendermodel_test.cpp
@@ -1,0 +1,56 @@
+#include <QtWidgets/QApplication>
+#include <canrawsender/canrawsendermodel.h>
+#include <datamodeltypes/canrawsenderdata.h>
+
+#define CATCH_CONFIG_RUNNER
+#include <fakeit.hpp>
+
+#include "log.hpp"
+std::shared_ptr<spdlog::logger> kDefaultLogger;
+
+#include <QSignalSpy>
+
+TEST_CASE("Test basic functionality", "[canrawsender]")
+{
+    CanRawSenderModel canRawSenderModel;
+    CHECK(canRawSenderModel.caption() == "CanRawSender Node");
+    CHECK(canRawSenderModel.name() == "CanRawSenderModel");
+    CHECK(canRawSenderModel.modelName() == "Raw sender");
+    CHECK(canRawSenderModel.resizable() == false);
+    CHECK(dynamic_cast<CanRawSenderModel*>(canRawSenderModel.clone().get()) != nullptr);
+    CHECK(dynamic_cast<QLabel*>(canRawSenderModel.embeddedWidget()) != nullptr);
+}
+
+TEST_CASE("Port information", "[canrawsender]")
+{
+    CanRawSenderModel canRawSenderModel;
+    CanRawSenderDataOut canRawSenderDataOut;
+    CHECK(canRawSenderModel.nPorts(PortType::Out) == 1);
+    CHECK(canRawSenderModel.nPorts(PortType::In) == 0);
+    CHECK(canRawSenderModel.nPorts(PortType::None) == 0);
+    CHECK(canRawSenderModel.dataType(PortType::Out, 0).id == canRawSenderDataOut.type().id);
+    CHECK(canRawSenderModel.dataType(PortType::Out, 0).name == canRawSenderDataOut.type().name);
+}
+
+TEST_CASE("Calling sendFrame emits dataUpdated and outData returns that frame", "[canrawsender]")
+{
+    CanRawSenderModel canRawSenderModel;
+    QCanBusFrame testFrame;
+    testFrame.setFrameId(123);
+    QSignalSpy dataUpdatedSpy(&canRawSenderModel, &CanRawSenderModel::dataUpdated);
+    canRawSenderModel.sendFrame(testFrame);
+    CHECK(dataUpdatedSpy.count() == 1);
+    CHECK(std::dynamic_pointer_cast<CanRawSenderDataOut>(canRawSenderModel.outData(0))->frame().frameId() == testFrame.frameId());
+}
+
+int main(int argc, char* argv[])
+{
+    bool haveDebug = std::getenv("CDS_DEBUG") != nullptr;
+    kDefaultLogger = spdlog::stdout_color_mt("cds");
+    if (haveDebug) {
+        kDefaultLogger->set_level(spdlog::level::debug);
+    }
+    cds_debug("Starting unit tests");
+    QApplication a(argc, argv); // QApplication must exist when contructing QWidgets TODO check QTest
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/canrawviewmodel_test.cpp
+++ b/tests/canrawviewmodel_test.cpp
@@ -1,0 +1,76 @@
+#include <QtWidgets/QApplication>
+#include <canrawview/canrawviewmodel.h>
+#include <datamodeltypes/canrawviewdata.h>
+
+#define CATCH_CONFIG_RUNNER
+#include <fakeit.hpp>
+
+#include "log.hpp"
+std::shared_ptr<spdlog::logger> kDefaultLogger;
+
+#include <QSignalSpy>
+// needed for QSignalSpy cause according to qtbug 49623 comments
+// automatic detection of types is "flawed" in moc
+Q_DECLARE_METATYPE(QCanBusFrame);
+
+TEST_CASE("Test basic functionality", "[canrawview]")
+{
+    using namespace fakeit;
+    CanRawViewModel canRawViewModel;
+    CHECK(canRawViewModel.caption() == "CanRawView Node");
+    CHECK(canRawViewModel.name() == "CanRawViewModel");
+    CHECK(canRawViewModel.modelName() == "Raw view");
+    CHECK(canRawViewModel.resizable() == false);
+    CHECK(dynamic_cast<CanRawViewModel*>(canRawViewModel.clone().get()) != nullptr);
+    CHECK(dynamic_cast<QLabel*>(canRawViewModel.embeddedWidget()) != nullptr);
+}
+
+TEST_CASE("Port information", "[canrawview]")
+{
+    CanRawViewModel canRawViewModel;
+    CanRawViewDataIn canRawViewDataIn;
+    CHECK(canRawViewModel.nPorts(PortType::Out) == 0);
+    CHECK(canRawViewModel.nPorts(PortType::In) == 1);
+    CHECK(canRawViewModel.nPorts(PortType::None) == 0);
+    CHECK(canRawViewModel.dataType(PortType::In, 0).id == canRawViewDataIn.type().id);
+    CHECK(canRawViewModel.dataType(PortType::In, 0).name == canRawViewDataIn.type().name);
+}
+
+TEST_CASE("Calling setInData with direction TX will result in frameSent being emitted", "[canrawview]")
+{
+    CanRawViewModel canRawViewModel;
+    QCanBusFrame testFrame;
+    testFrame.setFrameId(123);
+    auto canRawViewDataIn = std::make_shared<CanRawViewDataIn>(testFrame, Direction::TX, true);
+    QSignalSpy frameSentSpy(&canRawViewModel, &CanRawViewModel::frameSent);
+
+    canRawViewModel.setInData(canRawViewDataIn, 0);
+    CHECK(frameSentSpy.count() == 1);
+    CHECK(qvariant_cast<QCanBusFrame>(frameSentSpy.takeFirst().at(1)).frameId() == testFrame.frameId());
+}
+
+TEST_CASE("Calling setInData with direction RX will result in frameReceived being emitted", "[canrawview]")
+{
+    CanRawViewModel canRawViewModel;
+    QCanBusFrame testFrame;
+    testFrame.setFrameId(123);
+    auto canRawViewDataIn = std::make_shared<CanRawViewDataIn>(testFrame, Direction::RX, true);
+    QSignalSpy frameReceivedSpy(&canRawViewModel, &CanRawViewModel::frameReceived);
+
+    canRawViewModel.setInData(canRawViewDataIn, 0);
+    CHECK(frameReceivedSpy.count() == 1);
+    CHECK(qvariant_cast<QCanBusFrame>(frameReceivedSpy.takeFirst().at(0)).frameId() == testFrame.frameId());
+}
+
+int main(int argc, char* argv[])
+{
+    bool haveDebug = std::getenv("CDS_DEBUG") != nullptr;
+    kDefaultLogger = spdlog::stdout_color_mt("cds");
+    if (haveDebug) {
+        kDefaultLogger->set_level(spdlog::level::debug);
+    }
+    cds_debug("Staring unit tests");
+    qRegisterMetaType<QCanBusFrame>(); // required by QSignalSpy
+    QApplication a(argc, argv); // QApplication must exist when contructing QWidgets TODO check QTest
+    return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
Unit Tests for CanDeviceModel, CanRawSenderModel and CanRawViewModel.
Removal of unnecessary header inclusions. Minor refactor to be more consistent with design rules.

This is one proposal of how unit tests could be done. As you can see, QApplication must be created in main in order to properly construct embedded widgets. To avoid creating QApplication, a variant of QTEST_MAIN could be used, but that leads to abandoning CATCH due to conflicts.