### PR TITLE
Use default GNU libdir variable from CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 14)
 #libnodes.so will be installed to CANdevStudio dir to not override other installations. Set RPATH accordingly
-SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib/CANdevStudio)
+SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/CANdevStudio)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
@@ -104,7 +104,11 @@ if(WITH_TOOLS)
     add_subdirectory(tools)
 endif()
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/libnodes.so DESTINATION lib/CANdevStudio)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/libnodes.so DESTINATION ${CMAKE_INSTALL_LIBDIR}/CANdevStudio)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/src/components/projectconfig/libprojectconfig.so DESTINATION ${CMAKE_INSTALL_LIBDIR}/CANdevStudio)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/src/components/canrawsender/libcanrawsender.so DESTINATION ${CMAKE_INSTALL_LIBDIR}/CANdevStudio)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/src/components/canrawview/libcanrawview.so DESTINATION ${CMAKE_INSTALL_LIBDIR}/CANdevStudio)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/src/components/candevice/libcandevice.so DESTINATION ${CMAKE_INSTALL_LIBDIR}/CANdevStudio)
 
 #Cannelloni is supported on Linux only
 if(UNIX)


### PR DESCRIPTION
More reliable across distro which could have different
libdir name 'lib64' or 'lib' by example.

Change-Id: Ia89958f03f2cd86946f740a1a89c0d5cb8ed8532
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>