### PR TITLE
Add possibility to pass configuration to QCanBusDevice

### DIFF
--- a/src/common/componentinterface.h
+++ b/src/common/componentinterface.h
@@ -63,8 +63,7 @@ struct ComponentInterface {
     virtual std::shared_ptr<QObject> getQConfig() const = 0;
 
     using PropertyEditable = bool;
-    using ComponentProperties = std::map<QString,
-            std::pair<QVariant::Type, PropertyEditable>>;
+    using ComponentProperties = std::vector<std::tuple<QString, QVariant::Type, PropertyEditable>>;
 
     /**
      * Gets list of properties supported by this component

--- a/src/common/confighelpers.h
+++ b/src/common/confighelpers.h
@@ -8,42 +8,40 @@
 #include <map>
 #include <memory>
 
-class configHelpers
-{
+class configHelpers {
 
 public:
-static std::shared_ptr<QObject> getQConfig(const ComponentInterface::ComponentProperties& sp,
-        const std::map<QString, QVariant>& properties)
-{
-    std::shared_ptr<QObject> q = std::make_shared<QObject>();
-
-    QStringList props;
-    for (auto& p: sp)
+    static std::shared_ptr<QObject> getQConfig(
+        const ComponentInterface::ComponentProperties& sp, const std::map<QString, QVariant>& properties)
     {
-        if (p.second.second) // property editable
-        {
-            props.push_back(p.first);
-            q->setProperty(p.first.toStdString().c_str(), properties.at(p.first));
+        std::shared_ptr<QObject> q = std::make_shared<QObject>();
+
+        QStringList props;
+        for (auto& p : sp) {
+            if (std::get<2>(p)) {
+                // property editable
+                QString propName = std::get<0>(p);
+                props.push_back(propName);
+                q->setProperty(propName.toStdString().c_str(), properties.at(propName));
+            }
+        }
+
+        q->setProperty("exposedProperties", props);
+
+        return q;
+    }
+
+    static void setQConfig(const QObject& qobject, const ComponentInterface::ComponentProperties& sp,
+        std::map<QString, QVariant>& properties)
+    {
+        for (auto& p : sp) {
+            QString propName = std::get<0>(p);
+            QVariant v = qobject.property(propName.toStdString().c_str());
+            if (v.isValid() && v.type() == std::get<1>(p)) {
+                properties[propName] = v;
+            }
         }
     }
-
-    q->setProperty("exposedProperties", props);
-
-    return q;
-}
-
-static void setQConfig(const QObject& qobject,
-        const ComponentInterface::ComponentProperties& sp,
-        std::map<QString, QVariant>& properties)
-{
-    for (auto& p: sp)
-    {
-        QVariant v = qobject.property(p.first.toStdString().c_str());
-        if (v.isValid() && v.type() == p.second.first)
-            properties[p.first] = v;
-    }
-}
-
 };
 
 #endif /* SRC_COMMON_CONFIGHELPERS_H_ */

--- a/src/components/candevice/candevice.cpp
+++ b/src/components/candevice/candevice.cpp
@@ -45,6 +45,10 @@ bool CanDevice::init()
         d->_canDevice.setFramesReceivedCbk(std::bind(&CanDevice::framesReceived, this));
         d->_canDevice.setErrorOccurredCbk(std::bind(&CanDevice::errorOccurred, this, std::placeholders::_1));
 
+        for (auto &item : d->getDevConfig()) {
+            d->_canDevice.setConfigurationParameter(item.first, item.second);
+        }
+
         d->_initialized = true;
     }
 

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -123,9 +123,11 @@ private:
         } else if (keyStr == "CanFdKey") {
             key = QCanBusDevice::CanFdKey;
             val = valStr.toUpper() == "TRUE";
+#if QT_VERSION >= 0x050900
         } else if (keyStr == "DataBitRateKey") {
             key = QCanBusDevice::DataBitRateKey;
             val = valStr.toUInt(&res);
+#endif
         } else if (keyStr == "UserKey") {
             key = QCanBusDevice::UserKey;
             val = valStr;

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -75,10 +75,10 @@ public:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty,  QVariant::String, true},
-            {_backendProperty, QVariant::String, true},
-            {_interfaceProperty, QVariant::String, true},
-            {_configProperty, QVariant::String, true}
+            std::make_tuple(_nameProperty,  QVariant::String, true),
+            std::make_tuple(_backendProperty, QVariant::String, true),
+            std::make_tuple(_interfaceProperty, QVariant::String, true),
+            std::make_tuple(_configProperty, QVariant::String, true)
     };
     // clang-format on
 

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -110,7 +110,7 @@ private:
             cds_error("RawFilterKey not supported");
             res = false;
         } else if (keyStr == "ErrorFilterKey") {
-            cds_error("RawFilterKey not supported");
+            cds_error("ErrorFilterKey not supported");
             res = false;
         } else if (keyStr == "LoopbackKey") {
             key = QCanBusDevice::LoopbackKey;

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -35,8 +35,9 @@ public:
     bool restoreConfiguration(const QJsonObject& json)
     {
         for (const auto& p : _supportedProps) {
-            if (json.contains(p.first))
-                _props[p.first] = json[p.first].toVariant();
+            QString propName = std::get<0>(p);
+            if (json.contains(propName))
+                _props[propName] = json[propName].toVariant();
         }
         return true;
     }
@@ -74,10 +75,10 @@ public:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty,   {QVariant::String, true}},
-            {_backendProperty,   {QVariant::String, true}},
-            {_interfaceProperty, {QVariant::String, true}},
-            {_configProperty, {QVariant::String, true}}
+            {_nameProperty,  QVariant::String, true},
+            {_backendProperty, QVariant::String, true},
+            {_interfaceProperty, QVariant::String, true},
+            {_configProperty, QVariant::String, true}
     };
     // clang-format on
 
@@ -87,7 +88,7 @@ private:
     void initProps()
     {
         for (const auto& p : _supportedProps) {
-            _props[p.first];
+            _props[std::get<0>(p)];
         }
     }
 

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -14,7 +14,7 @@ class CanDevicePrivate {
     Q_DECLARE_PUBLIC(CanDevice)
 
 public:
-    CanDevicePrivate(CanDevice *q, CanDeviceCtx&& ctx = CanDeviceCtx(new CanDeviceQt()))
+    CanDevicePrivate(CanDevice* q, CanDeviceCtx&& ctx = CanDeviceCtx(new CanDeviceQt()))
         : _ctx(std::move(ctx))
         , _canDevice(_ctx.get<CanDeviceInterface>())
         , q_ptr(q)
@@ -27,20 +27,38 @@ public:
     {
         QJsonArray viewModelsArray;
 
-        for (const auto& p: _props)
-        {
+        for (const auto& p : _props) {
             json[p.first] = QJsonValue::fromVariant(p.second);
         }
     }
 
     bool restoreConfiguration(const QJsonObject& json)
     {
-        for (const auto& p: _supportedProps)
-        {
+        for (const auto& p : _supportedProps) {
             if (json.contains(p.first))
                 _props[p.first] = json[p.first].toVariant();
         }
         return true;
+    }
+
+    using devConfigPair = std::pair<int, QVariant>;
+    std::vector<devConfigPair> getDevConfig()
+    {
+        QString c = _props.at(_configProperty).toString().simplified().replace(" ", "");
+        std::vector<devConfigPair> ret;
+
+        auto&& propList = c.split(";");
+
+        for (auto& item : propList) {
+            devConfigPair pair;
+            bool res = getConfigPair(item, pair);
+
+            if (res) {
+                ret.push_back(pair);
+            }
+        }
+
+        return ret;
     }
 
     CanDeviceCtx _ctx;
@@ -52,26 +70,79 @@ public:
     const QString _nameProperty = "name";
     const QString _backendProperty = "backend";
     const QString _interfaceProperty = "interface";
+    const QString _configProperty = "configuration";
 
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
             {_nameProperty,   {QVariant::String, true}},
             {_backendProperty,   {QVariant::String, true}},
-            {_interfaceProperty, {QVariant::String, true}}
+            {_interfaceProperty, {QVariant::String, true}},
+            {_configProperty, {QVariant::String, true}}
     };
+    // clang-format on
 
     std::map<QString, QVariant> _props;
 
 private:
     void initProps()
     {
-        for (const auto& p: _supportedProps)
-        {
+        for (const auto& p : _supportedProps) {
             _props[p.first];
         }
     }
 
-    CanDevice *q_ptr;
+    bool getConfigPair(const QString& in, devConfigPair& out)
+    {
+        auto configStr = in.split("=");
 
+        if (configStr.length() != 2) {
+            return false;
+        }
+
+        auto keyStr = configStr[0];
+        auto valStr = configStr[1];
+        QCanBusDevice::ConfigurationKey key;
+        QVariant val;
+        bool res = true;
+
+        if (keyStr == "RawFilterKey") {
+            cds_error("RawFilterKey not supported");
+            res = false;
+        } else if (keyStr == "ErrorFilterKey") {
+            cds_error("RawFilterKey not supported");
+            res = false;
+        } else if (keyStr == "LoopbackKey") {
+            key = QCanBusDevice::LoopbackKey;
+            val = valStr.toUpper() == "TRUE";
+        } else if (keyStr == "ReceiveOwnKey") {
+            key = QCanBusDevice::ReceiveOwnKey;
+            val = valStr.toUpper() == "TRUE";
+        } else if (keyStr == "BitRateKey") {
+            key = QCanBusDevice::BitRateKey;
+            val = valStr.toUInt(&res);
+        } else if (keyStr == "CanFdKey") {
+            key = QCanBusDevice::CanFdKey;
+            val = valStr.toUpper() == "TRUE";
+        } else if (keyStr == "DataBitRateKey") {
+            key = QCanBusDevice::DataBitRateKey;
+            val = valStr.toUInt(&res);
+        } else if (keyStr == "UserKey") {
+            key = QCanBusDevice::UserKey;
+            val = valStr;
+        } else {
+            cds_error("Failed to convert '{}' to ConfigurationKey", keyStr.toStdString());
+            res = false;
+        }
+
+        if (res) {
+            cds_debug("Key: {}({}), Val: {}", keyStr.toStdString(), key, val.toString().toStdString());
+            out = std::make_pair(key, val);
+        }
+
+        return res;
+    }
+
+    CanDevice* q_ptr;
 };
 
 #endif /* !__CANDEVICE_P_H */

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -96,12 +96,14 @@ private:
     {
         auto configStr = in.split("=");
 
-        if (configStr.length() != 2) {
+        if ((configStr.length() != 2) || ((configStr.length() == 2) && (configStr[1].length() == 0))) {
+            cds_error("Config parameter parse error");
             return false;
         }
 
         auto keyStr = configStr[0];
         auto valStr = configStr[1];
+
         QCanBusDevice::ConfigurationKey key;
         QVariant val;
         bool res = true;

--- a/src/components/candevice/candeviceinterface.h
+++ b/src/components/candevice/candeviceinterface.h
@@ -6,9 +6,7 @@
 #include <functional>
 
 struct CanDeviceInterface {
-    virtual ~CanDeviceInterface()
-    {
-    }
+    virtual ~CanDeviceInterface() {}
 
     typedef std::function<void(qint64)> framesWritten_t;
     typedef std::function<void()> framesReceived_t;
@@ -24,9 +22,10 @@ struct CanDeviceInterface {
     virtual void disconnectDevice() = 0;
     virtual qint64 framesAvailable() = 0;
     virtual void clearCallbacks() = 0;
+    virtual void setConfigurationParameter(int key, const QVariant& value) = 0;
 
     virtual QCanBusFrame readFrame() = 0;
-    virtual void setParent(QObject *parent) = 0;
+    virtual void setParent(QObject* parent) = 0;
 };
 
 #endif /* end of include guard: CANDEVICEINTERFACE_H_DNXOI7PW */

--- a/src/components/candevice/candeviceqt.h
+++ b/src/components/candevice/candeviceqt.h
@@ -125,7 +125,7 @@ struct CanDeviceQt : public CanDeviceInterface {
     virtual void setConfigurationParameter(int key, const QVariant& value) override
     {
         if (_device) {
-            setConfigurationParameter(key, value);
+            _device->setConfigurationParameter(key, value);
         } else {
             cds_error("candevice is null. Call init firts!");
             throw std::runtime_error("candevice is null. Call init first!");

--- a/src/components/candevice/candeviceqt.h
+++ b/src/components/candevice/candeviceqt.h
@@ -7,7 +7,7 @@
 #include <log.h>
 
 struct CanDeviceQt : public CanDeviceInterface {
-    virtual void setParent(QObject *parent) override
+    virtual void setParent(QObject* parent) override
     {
         _parent = parent;
     }
@@ -53,7 +53,7 @@ struct CanDeviceQt : public CanDeviceInterface {
             return false;
         }
 
-        if(_parent && _parent->thread()) {
+        if (_parent && _parent->thread()) {
             _device->moveToThread(_parent->thread());
             _device->setParent(_parent);
         }
@@ -122,9 +122,19 @@ struct CanDeviceQt : public CanDeviceInterface {
         }
     }
 
+    virtual void setConfigurationParameter(int key, const QVariant& value) override
+    {
+        if (_device) {
+            setConfigurationParameter(key, value);
+        } else {
+            cds_error("candevice is null. Call init firts!");
+            throw std::runtime_error("candevice is null. Call init first!");
+        }
+    }
+
 private:
-    QCanBusDevice* _device{nullptr};
-    QObject* _parent{nullptr};
+    QCanBusDevice* _device{ nullptr };
+    QObject* _parent{ nullptr };
 };
 
 #endif /* end of include guard: CANDEVICEQT_H_JYBV8GIQ */

--- a/src/components/candevice/tests/candevice_test.cpp
+++ b/src/components/candevice/tests/candevice_test.cpp
@@ -415,7 +415,10 @@ auto prepareConfigTestMock()
     Fake(Method(deviceMock, clearCallbacks));
     Fake(Method(deviceMock, setParent));
     When(Method(deviceMock, init)).AlwaysReturn(true);
-    Fake(Method(deviceMock, setConfigurationParameter));
+    // Fake(Method(deviceMock, setConfigurationParameter));
+    When(Method(deviceMock, setConfigurationParameter)).AlwaysDo([&](int key, const QVariant& v) {
+        cds_info("A qqq {} : {}", key, v.toString().toStdString());
+    });
     return deviceMock;
 }
 
@@ -433,15 +436,14 @@ void testConfig(fakeit::Mock<CanDeviceInterface>& deviceMock, CanDevice& canDevi
 }
 
 // Use macro so Catch could show exact line of failure
-#define testConfig_Expect0(mock, dev, str) \
-    testConfig(mock, dev, str); \
+#define testConfig_Expect0(mock, dev, str)                                                                             \
+    testConfig(mock, dev, str);                                                                                        \
     fakeit::Verify(Method(mock, setConfigurationParameter)).Exactly(0);
 
 // Use macro so Catch could show exact line of failure
-#define testConfig_Expect1(mock, dev, key, val, str) \
-    testConfig(mock, dev, str); \
+#define testConfig_Expect1(mock, dev, key, val, str)                                                                   \
+    testConfig(mock, dev, str);                                                                                        \
     fakeit::Verify(Method(mock, setConfigurationParameter).Using(key, val)).Exactly(1);
-
 
 TEST_CASE("Config parameter - invalid format and unsupported", "[candevice]")
 {
@@ -561,15 +563,17 @@ TEST_CASE("Config parameter - UserKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "  UserKey  =    ");
 
     const int key = QCanBusDevice::UserKey;
-    //testConfig_Expect1(deviceMock, canDevice, key, "True", "UserKey=True");
-    //testConfig_Expect1(deviceMock, canDevice, key, "TexT", "UserKey=TexT;dummy=dummy");
-    //testConfig_Expect1(deviceMock, canDevice, key, 123456, "; dummy =    dummy;   UserKey=123456;dummy=dummy");
-    //testConfig_Expect1(deviceMock, canDevice, key, -111, "  UserKey =  -111; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, 0, "UserKey=0");
-    //testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=FALSE;dummy=dummy");
-    //testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   UserKey=TRU;dummy=dummy");
-    //testConfig_Expect1(deviceMock, canDevice, key, false, "  UserKey =  false; dummy=dummy");
-    //testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=dummy");
+    // testConfig_Expect1(deviceMock, canDevice, key, "True", "UserKey=True");
+    // testConfig_Expect1(deviceMock, canDevice, key, "TexT", "UserKey=TexT;dummy=dummy");
+    // testConfig_Expect1(deviceMock, canDevice, key, 123456, "; dummy =    dummy;   UserKey=123456;dummy=dummy");
+    // testConfig_Expect1(deviceMock, canDevice, key, -111, "  UserKey =  -111; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, QVariant("123"), "UserKey=123");
+    testConfig_Expect1(deviceMock, canDevice, key, QVariant("123"), "UserKey=123");
+    testConfig_Expect1(deviceMock, canDevice, key, "123", "UserKey=123");
+    // testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=FALSE;dummy=dummy");
+    // testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   UserKey=TRU;dummy=dummy");
+    // testConfig_Expect1(deviceMock, canDevice, key, false, "  UserKey =  false; dummy=dummy");
+    // testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=dummy");
 }
 
 #if QT_VERSION >= 0x050900
@@ -588,7 +592,8 @@ TEST_CASE("Config parameter - DataBitRateKey", "[candevice]")
 
     const int key = QCanBusDevice::DataBitRateKey;
     testConfig_Expect1(deviceMock, canDevice, key, 1000000, "DataBitRateKey=1000000");
-    testConfig_Expect1(deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   DataBitRateKey=123456789;dummy=dummy");
+    testConfig_Expect1(
+        deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   DataBitRateKey=123456789;dummy=dummy");
     testConfig_Expect1(deviceMock, canDevice, key, 1, "  DataBitRateKey =  1; dummy=dummy");
     testConfig_Expect1(deviceMock, canDevice, key, 0, "DataBitRateKey=0");
 }

--- a/src/components/candevice/tests/candevice_test.cpp
+++ b/src/components/candevice/tests/candevice_test.cpp
@@ -618,20 +618,10 @@ TEST_CASE("Config parameter - multiple keys", "[candevice]")
     testConfig(deviceMock, canDevice,
         "RawKeyFilter=;ErrorFilterKey;    LoopbackKey = true;    ReceiveOwnKey = false ;BitRateKey= "
         "100000;CanFdKey=true;UserKey=1000;");
-    fakeit::Verify(Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::LoopbackKey, true)
-        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::ReceiveOwnKey, false)
-        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::BitRateKey, 100000)
-        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::CanFdKey, true)
-        + Method(deviceMock, setConfigurationParameter))
-        .Exactly(1);
+    fakeit::Verify(Method(deviceMock, setConfigurationParameter)).Exactly(5);
 
     testConfig(deviceMock, canDevice,
         "RawKeyFilter=;ErrorFilterKey;    LoopbackKey = FALSE;    ReceiveOwnKey = TRue ;BitRateKey= "
         "666;CanFdKey=xxx;UserKey=1000;");
-    fakeit::Verify(Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::LoopbackKey, false)
-        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::ReceiveOwnKey, true)
-        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::BitRateKey, 666)
-        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::CanFdKey, false)
-        + Method(deviceMock, setConfigurationParameter))
-        .Exactly(1);
+    fakeit::Verify(Method(deviceMock, setConfigurationParameter)).Exactly(5);
 }

--- a/src/components/candevice/tests/candevice_test.cpp
+++ b/src/components/candevice/tests/candevice_test.cpp
@@ -441,9 +441,14 @@ void testConfig(fakeit::Mock<CanDeviceInterface>& deviceMock, CanDevice& canDevi
     fakeit::Verify(Method(mock, setConfigurationParameter)).Exactly(0);
 
 // Use macro so Catch could show exact line of failure
-#define testConfig_Expect1(mock, dev, key, val, str)                                                                   \
+#define testConfig_Expect1Using(mock, dev, key, val, str)                                                              \
     testConfig(mock, dev, str);                                                                                        \
     fakeit::Verify(Method(mock, setConfigurationParameter).Using(key, val)).Exactly(1);
+
+// Use macro so Catch could show exact line of failure
+#define testConfig_Expect1(mock, dev, str)                                                                             \
+    testConfig(mock, dev, str);                                                                                        \
+    fakeit::Verify(Method(mock, setConfigurationParameter)).Exactly(1);
 
 TEST_CASE("Config parameter - invalid format and unsupported", "[candevice]")
 {
@@ -474,15 +479,15 @@ TEST_CASE("Config parameter - LoopbackKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "  LoopbackKey  =    ");
 
     const int key = QCanBusDevice::LoopbackKey;
-    testConfig_Expect1(deviceMock, canDevice, key, true, "LoopbackKey=True");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "LoopbackKey=TRUE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "; dummy =    dummy;   LoopbackKey=TRUE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "  LoopbackKey =  true; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "LoopbackKey=False");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "LoopbackKey=FALSE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   LoopbackKey=TRU;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "  LoopbackKey =  false; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "LoopbackKey=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "LoopbackKey=True");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "LoopbackKey=TRUE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "; dummy =    dummy;   LoopbackKey=TRUE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "  LoopbackKey =  true; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "LoopbackKey=False");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "LoopbackKey=FALSE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "; dummy =    dummy;   LoopbackKey=TRU;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "  LoopbackKey =  false; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "LoopbackKey=dummy");
 }
 
 TEST_CASE("Config parameter - ReceiveOwnKey", "[candevice]")
@@ -497,15 +502,15 @@ TEST_CASE("Config parameter - ReceiveOwnKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "  ReceiveOwnKey  =    ");
 
     const int key = QCanBusDevice::ReceiveOwnKey;
-    testConfig_Expect1(deviceMock, canDevice, key, true, "ReceiveOwnKey=True");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "ReceiveOwnKey=TRUE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "; dummy =    dummy;   ReceiveOwnKey=TRUE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "  ReceiveOwnKey =  true; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "ReceiveOwnKey=False");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "ReceiveOwnKey=FALSE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   ReceiveOwnKey=TRU;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "  ReceiveOwnKey =  false; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "ReceiveOwnKey=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "ReceiveOwnKey=True");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "ReceiveOwnKey=TRUE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "; dummy =    dummy;   ReceiveOwnKey=TRUE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "  ReceiveOwnKey =  true; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "ReceiveOwnKey=False");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "ReceiveOwnKey=FALSE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "; dummy =    dummy;   ReceiveOwnKey=TRU;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "  ReceiveOwnKey =  false; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "ReceiveOwnKey=dummy");
 }
 
 TEST_CASE("Config parameter - CanFdKey", "[candevice]")
@@ -520,15 +525,15 @@ TEST_CASE("Config parameter - CanFdKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "  CanFdKey  =    ");
 
     const int key = QCanBusDevice::CanFdKey;
-    testConfig_Expect1(deviceMock, canDevice, key, true, "CanFdKey=True");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "CanFdKey=TRUE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "; dummy =    dummy;   CanFdKey=TRUE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, true, "  CanFdKey =  true; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "CanFdKey=False");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "CanFdKey=FALSE;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   CanFdKey=TRU;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "  CanFdKey =  false; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, false, "CanFdKey=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "CanFdKey=True");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "CanFdKey=TRUE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "; dummy =    dummy;   CanFdKey=TRUE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, true, "  CanFdKey =  true; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "CanFdKey=False");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "CanFdKey=FALSE;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "; dummy =    dummy;   CanFdKey=TRU;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "  CanFdKey =  false; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, false, "CanFdKey=dummy");
 }
 
 TEST_CASE("Config parameter - BitRateKey", "[candevice]")
@@ -545,10 +550,11 @@ TEST_CASE("Config parameter - BitRateKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "  BitRateKey  =   asdasd ");
 
     const int key = QCanBusDevice::BitRateKey;
-    testConfig_Expect1(deviceMock, canDevice, key, 1000000, "BitRateKey=1000000");
-    testConfig_Expect1(deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   BitRateKey=123456789;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, 1, "  BitRateKey =  1; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, 0, "BitRateKey=0");
+    testConfig_Expect1Using(deviceMock, canDevice, key, 1000000, "BitRateKey=1000000");
+    testConfig_Expect1Using(
+        deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   BitRateKey=123456789;dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, 1, "  BitRateKey =  1; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, 0, "BitRateKey=0");
 }
 
 TEST_CASE("Config parameter - UserKey", "[candevice]")
@@ -562,18 +568,15 @@ TEST_CASE("Config parameter - UserKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "UserKey=");
     testConfig_Expect0(deviceMock, canDevice, "  UserKey  =    ");
 
-    const int key = QCanBusDevice::UserKey;
-    // testConfig_Expect1(deviceMock, canDevice, key, "True", "UserKey=True");
-    // testConfig_Expect1(deviceMock, canDevice, key, "TexT", "UserKey=TexT;dummy=dummy");
-    // testConfig_Expect1(deviceMock, canDevice, key, 123456, "; dummy =    dummy;   UserKey=123456;dummy=dummy");
-    // testConfig_Expect1(deviceMock, canDevice, key, -111, "  UserKey =  -111; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, QVariant("123"), "UserKey=123");
-    testConfig_Expect1(deviceMock, canDevice, key, QVariant("123"), "UserKey=123");
-    testConfig_Expect1(deviceMock, canDevice, key, "123", "UserKey=123");
-    // testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=FALSE;dummy=dummy");
-    // testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   UserKey=TRU;dummy=dummy");
-    // testConfig_Expect1(deviceMock, canDevice, key, false, "  UserKey =  false; dummy=dummy");
-    // testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=dummy");
+    // Fakeit has problems with checking parameters of invokation in this particular case.
+    testConfig_Expect1(deviceMock, canDevice, "UserKey=True");
+    testConfig_Expect1(deviceMock, canDevice, "UserKey=TexT;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, "; dummy =    dummy;   UserKey=123456;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, "  UserKey =  -111; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, "UserKey=FALSE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, "; dummy =    dummy;   UserKey=TRU;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, "  UserKey =  false; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, "UserKey=dummy");
 }
 
 #if QT_VERSION >= 0x050900
@@ -591,10 +594,44 @@ TEST_CASE("Config parameter - DataBitRateKey", "[candevice]")
     testConfig_Expect0(deviceMock, canDevice, "  DataBitRateKey  =   asdasd ");
 
     const int key = QCanBusDevice::DataBitRateKey;
-    testConfig_Expect1(deviceMock, canDevice, key, 1000000, "DataBitRateKey=1000000");
-    testConfig_Expect1(
+    testConfig_Expect1Using(deviceMock, canDevice, key, 1000000, "DataBitRateKey=1000000");
+    testConfig_Expect1Using(
         deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   DataBitRateKey=123456789;dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, 1, "  DataBitRateKey =  1; dummy=dummy");
-    testConfig_Expect1(deviceMock, canDevice, key, 0, "DataBitRateKey=0");
+    testConfig_Expect1Using(deviceMock, canDevice, key, 1, "  DataBitRateKey =  1; dummy=dummy");
+    testConfig_Expect1Using(deviceMock, canDevice, key, 0, "DataBitRateKey=0");
 }
 #endif
+
+TEST_CASE("Config parameter - multiple keys", "[candevice]")
+{
+    using namespace fakeit;
+    auto&& deviceMock = prepareConfigTestMock();
+
+    CanDevice canDevice{ CanDeviceCtx(&deviceMock.get()) };
+
+    testConfig_Expect0(deviceMock, canDevice,
+        "RawKeyFilter;ErrorFilterKey;LoopbackKey;ReceiveOwnKey;BitRateKey;CanFdKey;DataBitRateKey;UserKey");
+    testConfig_Expect0(deviceMock, canDevice,
+        "RawKeyFilter=;   ErrorFilterKey   =;    LoopbackKey;    "
+        "ReceiveOwnKey;BitRateKey;CanFdKey;DataBitRateKey;UserKey=;");
+
+    testConfig(deviceMock, canDevice,
+        "RawKeyFilter=;ErrorFilterKey;    LoopbackKey = true;    ReceiveOwnKey = false ;BitRateKey= "
+        "100000;CanFdKey=true;UserKey=1000;");
+    fakeit::Verify(Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::LoopbackKey, true)
+        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::ReceiveOwnKey, false)
+        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::BitRateKey, 100000)
+        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::CanFdKey, true)
+        + Method(deviceMock, setConfigurationParameter))
+        .Exactly(1);
+
+    testConfig(deviceMock, canDevice,
+        "RawKeyFilter=;ErrorFilterKey;    LoopbackKey = FALSE;    ReceiveOwnKey = TRue ;BitRateKey= "
+        "666;CanFdKey=xxx;UserKey=1000;");
+    fakeit::Verify(Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::LoopbackKey, false)
+        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::ReceiveOwnKey, true)
+        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::BitRateKey, 666)
+        + Method(deviceMock, setConfigurationParameter).Using(QCanBusDevice::CanFdKey, false)
+        + Method(deviceMock, setConfigurationParameter))
+        .Exactly(1);
+}

--- a/src/components/candevice/tests/candevice_test.cpp
+++ b/src/components/candevice/tests/candevice_test.cpp
@@ -482,3 +482,114 @@ TEST_CASE("Config parameter - LoopbackKey", "[candevice]")
     testConfig_Expect1(deviceMock, canDevice, key, false, "  LoopbackKey =  false; dummy=dummy");
     testConfig_Expect1(deviceMock, canDevice, key, false, "LoopbackKey=dummy");
 }
+
+TEST_CASE("Config parameter - ReceiveOwnKey", "[candevice]")
+{
+    using namespace fakeit;
+    auto&& deviceMock = prepareConfigTestMock();
+
+    CanDevice canDevice{ CanDeviceCtx(&deviceMock.get()) };
+
+    testConfig_Expect0(deviceMock, canDevice, "ReceiveOwnKey");
+    testConfig_Expect0(deviceMock, canDevice, "ReceiveOwnKey=");
+    testConfig_Expect0(deviceMock, canDevice, "  ReceiveOwnKey  =    ");
+
+    const int key = QCanBusDevice::ReceiveOwnKey;
+    testConfig_Expect1(deviceMock, canDevice, key, true, "ReceiveOwnKey=True");
+    testConfig_Expect1(deviceMock, canDevice, key, true, "ReceiveOwnKey=TRUE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, true, "; dummy =    dummy;   ReceiveOwnKey=TRUE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, true, "  ReceiveOwnKey =  true; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "ReceiveOwnKey=False");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "ReceiveOwnKey=FALSE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   ReceiveOwnKey=TRU;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "  ReceiveOwnKey =  false; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "ReceiveOwnKey=dummy");
+}
+
+TEST_CASE("Config parameter - CanFdKey", "[candevice]")
+{
+    using namespace fakeit;
+    auto&& deviceMock = prepareConfigTestMock();
+
+    CanDevice canDevice{ CanDeviceCtx(&deviceMock.get()) };
+
+    testConfig_Expect0(deviceMock, canDevice, "CanFdKey");
+    testConfig_Expect0(deviceMock, canDevice, "CanFdKey=");
+    testConfig_Expect0(deviceMock, canDevice, "  CanFdKey  =    ");
+
+    const int key = QCanBusDevice::CanFdKey;
+    testConfig_Expect1(deviceMock, canDevice, key, true, "CanFdKey=True");
+    testConfig_Expect1(deviceMock, canDevice, key, true, "CanFdKey=TRUE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, true, "; dummy =    dummy;   CanFdKey=TRUE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, true, "  CanFdKey =  true; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "CanFdKey=False");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "CanFdKey=FALSE;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   CanFdKey=TRU;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "  CanFdKey =  false; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, false, "CanFdKey=dummy");
+}
+
+TEST_CASE("Config parameter - BitRateKey", "[candevice]")
+{
+    using namespace fakeit;
+    auto&& deviceMock = prepareConfigTestMock();
+
+    CanDevice canDevice{ CanDeviceCtx(&deviceMock.get()) };
+
+    testConfig_Expect0(deviceMock, canDevice, "BitRateKey");
+    testConfig_Expect0(deviceMock, canDevice, "BitRateKey=");
+    testConfig_Expect0(deviceMock, canDevice, "  BitRateKey  =   ");
+    testConfig_Expect0(deviceMock, canDevice, "  BitRateKey  =   -1 ");
+    testConfig_Expect0(deviceMock, canDevice, "  BitRateKey  =   asdasd ");
+
+    const int key = QCanBusDevice::BitRateKey;
+    testConfig_Expect1(deviceMock, canDevice, key, 1000000, "BitRateKey=1000000");
+    testConfig_Expect1(deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   BitRateKey=123456789;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, 1, "  BitRateKey =  1; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, 0, "BitRateKey=0");
+}
+
+TEST_CASE("Config parameter - UserKey", "[candevice]")
+{
+    using namespace fakeit;
+    auto&& deviceMock = prepareConfigTestMock();
+
+    CanDevice canDevice{ CanDeviceCtx(&deviceMock.get()) };
+
+    testConfig_Expect0(deviceMock, canDevice, "UserKey");
+    testConfig_Expect0(deviceMock, canDevice, "UserKey=");
+    testConfig_Expect0(deviceMock, canDevice, "  UserKey  =    ");
+
+    const int key = QCanBusDevice::UserKey;
+    //testConfig_Expect1(deviceMock, canDevice, key, "True", "UserKey=True");
+    //testConfig_Expect1(deviceMock, canDevice, key, "TexT", "UserKey=TexT;dummy=dummy");
+    //testConfig_Expect1(deviceMock, canDevice, key, 123456, "; dummy =    dummy;   UserKey=123456;dummy=dummy");
+    //testConfig_Expect1(deviceMock, canDevice, key, -111, "  UserKey =  -111; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, 0, "UserKey=0");
+    //testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=FALSE;dummy=dummy");
+    //testConfig_Expect1(deviceMock, canDevice, key, false, "; dummy =    dummy;   UserKey=TRU;dummy=dummy");
+    //testConfig_Expect1(deviceMock, canDevice, key, false, "  UserKey =  false; dummy=dummy");
+    //testConfig_Expect1(deviceMock, canDevice, key, false, "UserKey=dummy");
+}
+
+#if QT_VERSION >= 0x050900
+TEST_CASE("Config parameter - DataBitRateKey", "[candevice]")
+{
+    using namespace fakeit;
+    auto&& deviceMock = prepareConfigTestMock();
+
+    CanDevice canDevice{ CanDeviceCtx(&deviceMock.get()) };
+
+    testConfig_Expect0(deviceMock, canDevice, "DataBitRateKey");
+    testConfig_Expect0(deviceMock, canDevice, "DataBitRateKey=");
+    testConfig_Expect0(deviceMock, canDevice, "  DataBitRateKey  =   ");
+    testConfig_Expect0(deviceMock, canDevice, "  DataBitRateKey  =   -1 ");
+    testConfig_Expect0(deviceMock, canDevice, "  DataBitRateKey  =   asdasd ");
+
+    const int key = QCanBusDevice::DataBitRateKey;
+    testConfig_Expect1(deviceMock, canDevice, key, 1000000, "DataBitRateKey=1000000");
+    testConfig_Expect1(deviceMock, canDevice, key, 123456789, "; dummy =    dummy;   DataBitRateKey=123456789;dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, 1, "  DataBitRateKey =  1; dummy=dummy");
+    testConfig_Expect1(deviceMock, canDevice, key, 0, "DataBitRateKey=0");
+}
+#endif

--- a/src/components/canload/canload_p.cpp
+++ b/src/components/canload/canload_p.cpp
@@ -22,7 +22,7 @@ CanLoadPrivate::CanLoadPrivate(CanLoad* q, CanLoadCtx&& ctx)
 void CanLoadPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[p.first];
+        _props[std::get<0>(p)];
     }
 
     // Default value
@@ -40,7 +40,7 @@ QJsonObject CanLoadPrivate::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {
-        json[p.first] = QJsonValue::fromVariant(p.second);
+        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
     }
 
     return json;
@@ -49,8 +49,9 @@ QJsonObject CanLoadPrivate::getSettings()
 void CanLoadPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        if (json.contains(p.first))
-            _props[p.first] = json[p.first].toVariant();
+        QString propName = std::get<0>(p);
+        if (json.contains(propName))
+            _props[propName] = json[propName].toVariant();
     }
 
     _bitrate = _props[_bitrateProperty].toInt();

--- a/src/components/canload/canload_p.h
+++ b/src/components/canload/canload_p.h
@@ -36,11 +36,13 @@ public:
 
 private:
     CanLoad* q_ptr;
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_bitrateProperty,   {QVariant::String, true}},
-            {_periodProperty,   {QVariant::String, true}},
-            {_nameProperty,   {QVariant::String, true}}
+            {_nameProperty, QVariant::String, true},
+            {_bitrateProperty, QVariant::String, true},
+            {_periodProperty, QVariant::String, true}
     };
+    // clang-format on
 };
 
 #endif // CANLOAD_P_H

--- a/src/components/canload/canload_p.h
+++ b/src/components/canload/canload_p.h
@@ -38,9 +38,9 @@ private:
     CanLoad* q_ptr;
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty, QVariant::String, true},
-            {_bitrateProperty, QVariant::String, true},
-            {_periodProperty, QVariant::String, true}
+            std::make_tuple(_nameProperty, QVariant::String, true),
+            std::make_tuple(_bitrateProperty, QVariant::String, true),
+            std::make_tuple(_periodProperty, QVariant::String, true)
     };
     // clang-format on
 };

--- a/src/components/canload/tests/canload_test.cpp
+++ b/src/components/canload/tests/canload_test.cpp
@@ -54,10 +54,14 @@ TEST_CASE("getSupportedProperties", "[canload]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(props.find("name") != props.end());
-    CHECK(props.find("period [ms]") != props.end());
-    CHECK(props.find("bitrate [bps]") != props.end());
-    CHECK(props.find("dummy") == props.end());
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("period [ms]", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("bitrate [bps]", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+        == std::end(props));
 }
 
 TEST_CASE("start/stop - correct timings", "[canload]")

--- a/src/components/canrawfilter/canrawfilter_p.cpp
+++ b/src/components/canrawfilter/canrawfilter_p.cpp
@@ -35,7 +35,7 @@ CanRawFilterPrivate::CanRawFilterPrivate(CanRawFilter* q, CanRawFilterCtx&& ctx)
 void CanRawFilterPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[p.first];
+        _props[std::get<0>(p)];
     }
 }
 
@@ -110,8 +110,9 @@ CanRawFilterGuiInt::AcceptList_t CanRawFilterPrivate::getAcceptList(const QJsonO
 void CanRawFilterPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        if (json.contains(p.first))
-            _props[p.first] = json[p.first].toVariant();
+        QString propName = std::get<0>(p);
+        if (json.contains(propName))
+            _props[propName] = json[propName].toVariant();
     }
 
     auto&& rxList = getAcceptList(json, "rxList");

--- a/src/components/canrawfilter/canrawfilter_p.h
+++ b/src/components/canrawfilter/canrawfilter_p.h
@@ -1,8 +1,8 @@
 #ifndef CANRAWFILTER_P_H
 #define CANRAWFILTER_P_H
 
-#include "gui/canrawfilterguiimpl.h"
 #include "canrawfilter.h"
+#include "gui/canrawfilterguiimpl.h"
 #include <QtCore/QObject>
 #include <memory>
 
@@ -22,7 +22,7 @@ public:
 
 private:
     void initProps();
-    bool acceptFrame(const CanRawFilterGuiInt::AcceptList_t &list, const QCanBusFrame &frame);
+    bool acceptFrame(const CanRawFilterGuiInt::AcceptList_t& list, const QCanBusFrame& frame);
     CanRawFilterGuiInt::AcceptList_t getAcceptList(const QJsonObject& json, const QString& listName);
 
 public:
@@ -37,9 +37,11 @@ private:
     CanRawFilterGuiInt::AcceptList_t _txAcceptList;
     CanRawFilter* q_ptr;
     const QString _nameProperty = "name";
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty,   {QVariant::String, true}}
+            {_nameProperty, QVariant::String, true}
     };
+    // clang-format on
 };
 
 #endif // CANRAWFILTER_P_H

--- a/src/components/canrawfilter/canrawfilter_p.h
+++ b/src/components/canrawfilter/canrawfilter_p.h
@@ -39,7 +39,7 @@ private:
     const QString _nameProperty = "name";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty, QVariant::String, true}
+            std::make_tuple(_nameProperty, QVariant::String, true)
     };
     // clang-format on
 };

--- a/src/components/canrawfilter/tests/canrawfilter_test.cpp
+++ b/src/components/canrawfilter/tests/canrawfilter_test.cpp
@@ -104,8 +104,10 @@ TEST_CASE("getSupportedProperties", "[canrawfilter]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(props.find("name") != props.end());
-    CHECK(props.find("dummy") == props.end());
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+        == std::end(props));
 }
 
 TEST_CASE("default accept list RX", "[canrawfilter]")

--- a/src/components/canrawlogger/canrawlogger_p.cpp
+++ b/src/components/canrawlogger/canrawlogger_p.cpp
@@ -12,7 +12,7 @@ CanRawLoggerPrivate::CanRawLoggerPrivate(CanRawLogger* q, CanRawLoggerCtx&& ctx)
 void CanRawLoggerPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[p.first];
+        _props[std::get<0>(p)];
     }
 
     _props[_dirProperty] = ".";
@@ -28,7 +28,7 @@ QJsonObject CanRawLoggerPrivate::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {
-        json[p.first] = QJsonValue::fromVariant(p.second);
+        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
     }
 
     return json;
@@ -37,8 +37,9 @@ QJsonObject CanRawLoggerPrivate::getSettings()
 void CanRawLoggerPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        if (json.contains(p.first))
-            _props[p.first] = json[p.first].toVariant();
+        QString propName = std::get<0>(p);
+        if (json.contains(propName))
+            _props[propName] = json[propName].toVariant();
     }
 }
 

--- a/src/components/canrawlogger/canrawlogger_p.h
+++ b/src/components/canrawlogger/canrawlogger_p.h
@@ -2,10 +2,10 @@
 #define CANRAWLOGGER_P_H
 
 #include "canrawlogger.h"
+#include <QElapsedTimer>
+#include <QFile>
 #include <QtCore/QObject>
 #include <memory>
-#include <QFile>
-#include <QElapsedTimer>
 
 class CanRawLogger;
 
@@ -35,10 +35,12 @@ private:
     CanRawLogger* q_ptr;
     const QString _nameProperty = "name";
     const QString _dirProperty = "directory";
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_dirProperty,   {QVariant::String, true}},
-            {_nameProperty,   {QVariant::String, true}}
+            {_nameProperty,  QVariant::String, true},
+            {_dirProperty,  QVariant::String, true}
     };
+    // clang-format on
 };
 
 #endif // CANRAWLOGGER_P_H

--- a/src/components/canrawlogger/canrawlogger_p.h
+++ b/src/components/canrawlogger/canrawlogger_p.h
@@ -37,8 +37,8 @@ private:
     const QString _dirProperty = "directory";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty,  QVariant::String, true},
-            {_dirProperty,  QVariant::String, true}
+            std::make_tuple(_nameProperty,  QVariant::String, true),
+            std::make_tuple(_dirProperty,  QVariant::String, true)
     };
     // clang-format on
 };

--- a/src/components/canrawlogger/tests/canrawlogger_test.cpp
+++ b/src/components/canrawlogger/tests/canrawlogger_test.cpp
@@ -71,8 +71,12 @@ TEST_CASE("getSupportedProperties", "[canrawlogger]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(props.find("name") != props.end());
-    CHECK(props.find("dummy") == props.end());
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("directory", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+        == std::end(props));
 }
 
 TEST_CASE("logging - directories", "[canrawlogger]")
@@ -211,7 +215,7 @@ TEST_CASE("logging - send/receive", "[canrawlogger]")
     c.frameReceived(frame);
     c.frameReceived(frame);
     c.frameReceived(frame);
-
+    
     fileList = dir.entryList({ "*" });
     CHECK(fileList.size() == 3);
     msgCnt = loadTraceFile(dirName + "/" + fileList[2]);

--- a/src/components/canrawplayer/canrawplayer_p.cpp
+++ b/src/components/canrawplayer/canrawplayer_p.cpp
@@ -22,7 +22,7 @@ CanRawPlayerPrivate::CanRawPlayerPrivate(CanRawPlayer* q, CanRawPlayerCtx&& ctx)
 void CanRawPlayerPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[p.first];
+        _props[std::get<0>(p)];
     }
     
     _props[_tickProperty] = _tick;
@@ -38,7 +38,7 @@ QJsonObject CanRawPlayerPrivate::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {
-        json[p.first] = QJsonValue::fromVariant(p.second);
+        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
     }
 
     return json;
@@ -47,8 +47,9 @@ QJsonObject CanRawPlayerPrivate::getSettings()
 void CanRawPlayerPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        if (json.contains(p.first))
-            _props[p.first] = json[p.first].toVariant();
+        QString propName = std::get<0>(p);
+        if (json.contains(propName))
+            _props[propName] = json[propName].toVariant();
     }
 }
 

--- a/src/components/canrawplayer/canrawplayer_p.h
+++ b/src/components/canrawplayer/canrawplayer_p.h
@@ -46,9 +46,9 @@ private:
     QTimer _timer;
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty, QVariant::String, true},
-            {_fileProperty, QVariant::String, true},
-            {_tickProperty, QVariant::String, true}
+            std::make_tuple(_nameProperty, QVariant::String, true),
+            std::make_tuple(_fileProperty, QVariant::String, true),
+            std::make_tuple(_tickProperty, QVariant::String, true)
     };
     // clang-format on
 };

--- a/src/components/canrawplayer/canrawplayer_p.h
+++ b/src/components/canrawplayer/canrawplayer_p.h
@@ -44,11 +44,13 @@ private:
     uint32_t _frameNdx;
     uint32_t _ticks;
     QTimer _timer;
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty,   {QVariant::String, true}},
-            {_fileProperty,   {QVariant::String, true}},
-            {_tickProperty,   {QVariant::String, true}}
+            {_nameProperty, QVariant::String, true},
+            {_fileProperty, QVariant::String, true},
+            {_tickProperty, QVariant::String, true}
     };
+    // clang-format on
 };
 
 #endif // CANRAWPLAYER_P_H

--- a/src/components/canrawplayer/tests/canrawplayer_test.cpp
+++ b/src/components/canrawplayer/tests/canrawplayer_test.cpp
@@ -2,10 +2,10 @@
 #include <canrawplayer.h>
 #define CATCH_CONFIG_RUNNER
 #include "log.h"
+#include <QCanBusFrame>
 #include <QSignalSpy>
 #include <catch.hpp>
 #include <fakeit.hpp>
-#include <QCanBusFrame>
 
 std::shared_ptr<spdlog::logger> kDefaultLogger;
 // needed for QSignalSpy cause according to qtbug 49623 comments
@@ -80,10 +80,14 @@ TEST_CASE("getSupportedProperties", "[canrawplayer]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(props.find("name") != props.end());
-    CHECK(props.find("file") != props.end());
-    CHECK(props.find("timer tick [ms]") != props.end());
-    CHECK(props.find("dummy") == props.end());
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("file", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("timer tick [ms]", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+        == std::end(props));
 }
 
 static QString createTestFile()
@@ -130,7 +134,7 @@ static QString createTestFile2()
 
 TEST_CASE("Send test", "[canrawplayer]")
 {
-    using namespace std::chrono_literals;    
+    using namespace std::chrono_literals;
 
     CanRawPlayer c;
     QObject props;
@@ -138,7 +142,7 @@ TEST_CASE("Send test", "[canrawplayer]")
     QThread th;
 
     c.moveToThread(&th);
-    
+
     QObject::connect(&th, &QThread::started, &c, &CanRawPlayer::startSimulation);
     QObject::connect(&th, &QThread::finished, &c, &CanRawPlayer::stopSimulation);
 
@@ -158,7 +162,7 @@ TEST_CASE("Send test", "[canrawplayer]")
 
 TEST_CASE("Send test 2", "[canrawplayer]")
 {
-    using namespace std::chrono_literals;    
+    using namespace std::chrono_literals;
 
     CanRawPlayer c;
     QObject props;
@@ -166,7 +170,7 @@ TEST_CASE("Send test 2", "[canrawplayer]")
     QThread th;
 
     c.moveToThread(&th);
-    
+
     QObject::connect(&th, &QThread::started, &c, &CanRawPlayer::startSimulation);
     QObject::connect(&th, &QThread::finished, &c, &CanRawPlayer::stopSimulation);
 

--- a/src/components/canrawsender/canrawsender_p.h
+++ b/src/components/canrawsender/canrawsender_p.h
@@ -128,7 +128,7 @@ private:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty, QVariant::String, true}
+            std::make_tuple(_nameProperty, QVariant::String, true)
     };
     // clang-format on
 };

--- a/src/components/canrawsender/canrawsender_p.h
+++ b/src/components/canrawsender/canrawsender_p.h
@@ -98,7 +98,7 @@ private:
     {
         for (const auto& p: _supportedProps)
         {
-            _props[p.first];
+            _props[std::get<0>(p)];
         }
     }
 
@@ -126,9 +126,11 @@ private:
 
     const QString _nameProperty = "name";
 
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            {_nameProperty,   {QVariant::String, true}}
+            {_nameProperty, QVariant::String, true}
     };
+    // clang-format on
 };
 
 #endif // CANRAWSENDER_P_H

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -430,7 +430,7 @@ private:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            { _nameProperty, QVariant::String, true }
+            std::make_tuple(_nameProperty, QVariant::String, true)
     };
     // clang-format on
 };

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -1,8 +1,8 @@
 #ifndef CANRAWVIEW_P_H
 #define CANRAWVIEW_P_H
 
-#include "gui/crvgui.h"
 #include "crvsortmodel.h"
+#include "gui/crvgui.h"
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
@@ -48,16 +48,23 @@ public:
         _tvModel.setHeaderData(0, Qt::Horizontal, QVariant::fromValue(CRV_ColType::uint_type), Qt::UserRole); // rowID
         _tvModel.setHeaderData(1, Qt::Horizontal, QVariant::fromValue(CRV_ColType::double_type), Qt::UserRole); // time
         _tvModel.setHeaderData(2, Qt::Horizontal, QVariant::fromValue(CRV_ColType::hex_type), Qt::UserRole); // frame ID
-        _tvModel.setHeaderData(3, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // direction
+        _tvModel.setHeaderData(
+            3, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // direction
         _tvModel.setHeaderData(4, Qt::Horizontal, QVariant::fromValue(CRV_ColType::uint_type), Qt::UserRole); // length
         _tvModel.setHeaderData(5, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // data
 
-        _tvModelUnique.setHeaderData(0, Qt::Horizontal, QVariant::fromValue(CRV_ColType::uint_type), Qt::UserRole); // rowID
-        _tvModelUnique.setHeaderData(1, Qt::Horizontal, QVariant::fromValue(CRV_ColType::double_type), Qt::UserRole); // time
-        _tvModelUnique.setHeaderData(2, Qt::Horizontal, QVariant::fromValue(CRV_ColType::hex_type), Qt::UserRole); // frame ID
-        _tvModelUnique.setHeaderData(3, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // direction
-        _tvModelUnique.setHeaderData(4, Qt::Horizontal, QVariant::fromValue(CRV_ColType::uint_type), Qt::UserRole); // length
-        _tvModelUnique.setHeaderData(5, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // data
+        _tvModelUnique.setHeaderData(
+            0, Qt::Horizontal, QVariant::fromValue(CRV_ColType::uint_type), Qt::UserRole); // rowID
+        _tvModelUnique.setHeaderData(
+            1, Qt::Horizontal, QVariant::fromValue(CRV_ColType::double_type), Qt::UserRole); // time
+        _tvModelUnique.setHeaderData(
+            2, Qt::Horizontal, QVariant::fromValue(CRV_ColType::hex_type), Qt::UserRole); // frame ID
+        _tvModelUnique.setHeaderData(
+            3, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // direction
+        _tvModelUnique.setHeaderData(
+            4, Qt::Horizontal, QVariant::fromValue(CRV_ColType::uint_type), Qt::UserRole); // length
+        _tvModelUnique.setHeaderData(
+            5, Qt::Horizontal, QVariant::fromValue(CRV_ColType::str_type), Qt::UserRole); // data
     }
 
     ~CanRawViewPrivate() {}
@@ -108,7 +115,6 @@ public:
             (*it++)->setText(size);
             (*it++)->setText(data);
         }
-
 
         _tvModel.appendRow(list);
 
@@ -334,7 +340,7 @@ private:
     void initProps()
     {
         for (const auto& p : _supportedProps) {
-            _props[p.first];
+            _props[std::get<0>(p)];
         }
     }
 
@@ -422,6 +428,10 @@ private:
 
     const QString _nameProperty = "name";
 
-    ComponentInterface::ComponentProperties _supportedProps = { { _nameProperty, { QVariant::String, true } } };
+    // clang-format off
+    ComponentInterface::ComponentProperties _supportedProps = {
+            { _nameProperty, QVariant::String, true }
+    };
+    // clang-format on
 };
 #endif // CANRAWVIEW_P_H

--- a/tools/templategen/main.cpp
+++ b/tools/templategen/main.cpp
@@ -217,9 +217,11 @@ public:
 private:
     {name}* q_ptr;
     const QString _nameProperty = "name";
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            {{_nameProperty,   {{QVariant::String, true}}}}
+            {{ _nameProperty, QVariant::String, true }}
     }};
+    // clang-format on
 }};
 
 #endif // {nameUpper}_P_H
@@ -243,9 +245,8 @@ std::string genPrivateSrc(const std::string& name)
 
 void {name}Private::initProps()
 {{
-    for (const auto& p: _supportedProps)
-    {{
-        _props[p.first];
+    for (const auto& p: _supportedProps) {{
+        _props[std::get<0>(p)];
     }}
 }}
 
@@ -259,7 +260,7 @@ QJsonObject {name}Private::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {{
-        json[p.first] = QJsonValue::fromVariant(p.second);
+        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
     }}
 
     return json;
@@ -268,8 +269,9 @@ QJsonObject {name}Private::getSettings()
 void {name}Private::setSettings(const QJsonObject& json)
 {{
     for (const auto& p : _supportedProps) {{
-        if (json.contains(p.first))
-            _props[p.first] = json[p.first].toVariant();
+        QString propName = std::get<0>(p);
+        if (json.contains(propName))
+            _props[propName] = json[propName].toVariant();
     }}
 }}
 )",
@@ -483,9 +485,11 @@ public:
 private:
     {name}* q_ptr;
     const QString _nameProperty = "name";
+    // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            {{_nameProperty,   {{QVariant::String, true}}}}
+            {{ _nameProperty, QVariant::String, true }}
     }};
+    // clang-format on
 }};
 
 #endif // {nameUpper}_P_H
@@ -512,7 +516,7 @@ void {name}Private::initProps()
 {{
     for (const auto& p: _supportedProps)
     {{
-        _props[p.first];
+        _props[std::get<0>(p)];
     }}
 }}
 
@@ -526,7 +530,7 @@ QJsonObject {name}Private::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {{
-        json[p.first] = QJsonValue::fromVariant(p.second);
+        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
     }}
 
     return json;
@@ -535,8 +539,9 @@ QJsonObject {name}Private::getSettings()
 void {name}Private::setSettings(const QJsonObject& json)
 {{
     for (const auto& p : _supportedProps) {{
-        if (json.contains(p.first))
-            _props[p.first] = json[p.first].toVariant();
+        QString propName = std::get<0>(p);
+        if (json.contains(propName))
+            _props[propName] = json[propName].toVariant();
     }}
 }}
 )",
@@ -556,10 +561,7 @@ std::string genGuiInt(const std::string& name)
 class QWidget;
 
 struct {name}GuiInt {{
-    virtual ~{name}GuiInt()
-    {{
-    }}
-
+    virtual ~{name}GuiInt() {{}}
     virtual QWidget* mainWidget() = 0;
 }};
 
@@ -829,8 +831,10 @@ TEST_CASE("getSupportedProperties", "[{nameLower}]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(props.find("name") != props.end());
-    CHECK(props.find("dummy") == props.end());
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+        != std::end(props));
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+        == std::end(props));
 }}
 
 int main(int argc, char* argv[])

--- a/tools/templategen/main.cpp
+++ b/tools/templategen/main.cpp
@@ -219,7 +219,7 @@ private:
     const QString _nameProperty = "name";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            {{ _nameProperty, QVariant::String, true }}
+            std::make_tuple(_nameProperty, QVariant::String, true)
     }};
     // clang-format on
 }};
@@ -395,7 +395,7 @@ void {name}::setConfig(const QJsonObject& json)
 {{
     Q_D({name});
 
-    d_ptr->setSettings(json);
+    d->setSettings(json);
 }}
 
 void {name}::setConfig(const QObject& qobject)
@@ -487,7 +487,7 @@ private:
     const QString _nameProperty = "name";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            {{ _nameProperty, QVariant::String, true }}
+            std::make_tuple(_nameProperty, QVariant::String, true)
     }};
     // clang-format on
 }};

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -7,10 +7,6 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     ./travis/docker_compile.sh
     export CC=gcc-53 CXX=g++-53 CMAKE_BUILD_TYPE=Release WITH_COVERAGE=OFF PACKAGE=ON
     ./travis/docker_compile.sh
-    export CC=gcc-53 CXX=g++-53 CMAKE_BUILD_TYPE=Debug WITH_COVERAGE=OFF PACKAGE=OFF
-    ./travis/docker_compile.sh
-    export CC=clang-3.5 CXX=clang++-3.5 CMAKE_BUILD_TYPE=Release WITH_COVERAGE=OFF PACKAGE=OFF
-    ./travis/docker_compile.sh
     export CC=clang-3.5 CXX=clang++-3.5 CMAKE_BUILD_TYPE=Debug WITH_COVERAGE=OFF PACKAGE=OFF
     ./travis/docker_compile.sh
 else


### PR DESCRIPTION
- Resolution of #128 issue - configuration property added to candevice module
- properties keeps order of definition and are no longer sorted
- unit tests for new functionality
- number of builds reduced to fit in 50 minutes Travis limitation