### PR TITLE
Enhance PropertyEditorDialog fields

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
         - "src/components/canload/canloadpainter.h"
         - "src/common/guiinterface"
         - "src/common/nodepainter.h"
+        - "src/common/propertyfields.h"
         - "src/gui/main*"
         - "src/gui/subwindow.h"
         - "src/gui/projectconfig/flowviewwrapper.h"

--- a/files/css/darkStyle.css
+++ b/files/css/darkStyle.css
@@ -187,6 +187,14 @@ QPushButton:pressed[type="recentProjectName"], QPushButton:pressed[type="recentP
     background: #3a3a3a;
 }
 
+QPushButton[type="PropertyFieldPath"] {
+    background: #1d1d1d;
+    color: #cccccc;
+    margin-top: 2px;
+    margin-bottom: 1px;
+    margin-right: 3px;
+}
+
 QLabel[type="aboutLabel"] {
     background: #3a3a3a;
     color: #ffffff;

--- a/files/css/darkStyle.css
+++ b/files/css/darkStyle.css
@@ -247,3 +247,22 @@ QCheckBox::indicator:checked:disabled {
 QLabel[type="policyLabel"] {
     background: #616161;
 }
+
+
+QComboBox::drop-down {
+    background: #1d1d1d;
+}
+
+QComboBox::down-arrow {
+    background: #1d1d1d;
+    width: 18px;
+    height: 18px;
+    image: url(:/images/files/images/dark/Angle-down-01.svg);
+    padding-top: 3px;
+    padding-right: 8px;
+}
+
+QComboBox::down-arrow:on {
+    image: url(:/images/files/images/dark/Angle-up-01.svg);
+}
+

--- a/files/css/lightStyle.css
+++ b/files/css/lightStyle.css
@@ -203,6 +203,12 @@ QPushButton:pressed[type="recentProjectName"], QPushButton:pressed[type="recentP
     border: 0px;
 }
 
+QPushButton[type="PropertyFieldPath"] {
+    margin-top: 2px;
+    margin-bottom: 1px;
+    margin-right: 3px;
+}
+
 QLabel[type="aboutLabel"] {
     background: #ffffff;
     color: #282828;

--- a/files/css/lightStyle.css
+++ b/files/css/lightStyle.css
@@ -253,3 +253,21 @@ QCheckBox::indicator:checked:disabled {
     image: url(:/images/files/images/light/CANbus_icon_CheckBoxOn_disabled.svg);
     background-color: #ffffff;
 }
+
+QComboBox::drop-down {
+    background: white;
+}
+
+QComboBox::down-arrow {
+    background: white;
+    width: 18px;
+    height: 18px;
+    image: url(:/images/files/images/light/Angle-down-01.svg);
+    padding-top: 3px;
+    padding-right: 8px;
+}
+
+QComboBox::down-arrow:on {
+    image: url(:/images/files/images/light/Angle-up-01.svg);
+}
+

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/common ${CMAKE_SOURCE_DIR}/3rdParty/
 
 set(SRC
     componentmodel.h
+    propertyfields.h
     )
 
 add_library(cds-common STATIC ${SRC})

--- a/src/common/componentinterface.h
+++ b/src/common/componentinterface.h
@@ -1,8 +1,8 @@
 #ifndef __COMPONENTINTERFACE_H
 #define __COMPONENTINTERFACE_H
 
-#include <QtCore/QJsonObject>
 #include <QVariant>
+#include <QtCore/QJsonObject>
 #include <functional>
 #include <map>
 #include <memory>
@@ -10,40 +10,38 @@
 class QWidget;
 
 /**
-*   @brief  Interface to be implemented by every component
-*/
+ *   @brief  Interface to be implemented by every component
+ */
 struct ComponentInterface {
-    virtual ~ComponentInterface()
-    {
-    }
+    virtual ~ComponentInterface() {}
 
     /**
-    *   @brief  Signal to be implemented by Component. Indicates when dock/undock action was invoked. 
-    *   @param  widget Widget subjected to dock/undock action
-    */
+     *   @brief  Signal to be implemented by Component. Indicates when dock/undock action was invoked.
+     *   @param  widget Widget subjected to dock/undock action
+     */
     virtual void mainWidgetDockToggled(QWidget* widget) = 0;
 
     /**
-    *   @brief  Slot to be implemented by Component to execute simulation stop action
-    */
+     *   @brief  Slot to be implemented by Component to execute simulation stop action
+     */
     virtual void stopSimulation() = 0;
 
     /**
-    *   @brief  Slot to be implemented by Component to execute simulation start action
-    */
+     *   @brief  Slot to be implemented by Component to execute simulation start action
+     */
     virtual void startSimulation() = 0;
 
     /**
-    *   @brief  Sets configuration for component
-    *   @param  json configuration to be aplied
-    */
+     *   @brief  Sets configuration for component
+     *   @param  json configuration to be aplied
+     */
     virtual void setConfig(const QJsonObject& json) = 0;
 
     /**
-    *   @brief  Sets configuration for component
-    *   @param  QObject configuration to be aplied
-    */
-    virtual void setConfig(const QObject& qobject) = 0;
+     *   @brief  Sets configuration for component
+     *   @param  QWidget configuration to be aplied
+     */
+    virtual void setConfig(const QWidget& qobject) = 0;
 
     /**
      *  @brief  Reconfigure component if necessary
@@ -51,19 +49,41 @@ struct ComponentInterface {
     virtual void configChanged() = 0;
 
     /**
-    *   @brief  Gets current component configuation
-    *   @return current config
-    */
+     *   @brief  Gets current component configuation
+     *   @return current config
+     */
     virtual QJsonObject getConfig() const = 0;
 
     /**
-    *   @brief  Gets current component configuation
-    *   @return current config
-    */
-    virtual std::shared_ptr<QObject> getQConfig() const = 0;
+     *   @brief  Gets current component configuation
+     *   @return current config
+     */
+    virtual std::shared_ptr<QWidget> getQConfig() const = 0;
 
     using PropertyEditable = bool;
-    using ComponentProperties = std::vector<std::tuple<QString, QVariant::Type, PropertyEditable>>;
+    using CustomEditFieldCbk = std::function<QWidget*(void)>;
+    using ComponentProperty = std::tuple<QString, QVariant::Type, PropertyEditable, CustomEditFieldCbk>;
+    using ComponentProperties = std::vector<ComponentProperty>;
+
+    static constexpr const QString& propertyName(const ComponentProperty& p)
+    {
+        return std::get<0>(p);
+    }
+
+    static constexpr const QVariant::Type& propertyType(const ComponentProperty& p)
+    {
+        return std::get<1>(p);
+    }
+
+    static constexpr const PropertyEditable& propertyEditability(const ComponentProperty& p)
+    {
+        return std::get<2>(p);
+    }
+
+    static constexpr const CustomEditFieldCbk& propertyEditField(const ComponentProperty& p)
+    {
+        return std::get<3>(p);
+    }
 
     /**
      * Gets list of properties supported by this component
@@ -72,15 +92,15 @@ struct ComponentInterface {
     virtual ComponentProperties getSupportedProperties() const = 0;
 
     /**
-    *   @brief  Gets components's main widget
-    *   @return Main widget or nullptr if component doesn't have it
-    */
+     *   @brief  Gets components's main widget
+     *   @return Main widget or nullptr if component doesn't have it
+     */
     virtual QWidget* mainWidget() = 0;
 
     /**
-    *   @brief  Main widget docking status
-    *   @return returns true if widget is docked (part of MDI) or undocked (separate window)
-    */
+     *   @brief  Main widget docking status
+     *   @return returns true if widget is docked (part of MDI) or undocked (separate window)
+     */
     virtual bool mainWidgetDocked() const = 0;
 };
 

--- a/src/common/componentinterface.h
+++ b/src/common/componentinterface.h
@@ -80,7 +80,7 @@ struct ComponentInterface {
         return std::get<2>(p);
     }
 
-    static constexpr const CustomEditFieldCbk& propertyEditField(const ComponentProperty& p)
+    static constexpr const CustomEditFieldCbk& propertyField(const ComponentProperty& p)
     {
         return std::get<3>(p);
     }

--- a/src/common/confighelpers.h
+++ b/src/common/confighelpers.h
@@ -2,7 +2,7 @@
 #define SRC_COMMON_CONFIGHELPERS_H_
 
 #include "componentinterface.h"
-#include <QObject>
+#include <QWidget>
 #include <QVariant>
 
 #include <map>
@@ -11,16 +11,16 @@
 class configHelpers {
 
 public:
-    static std::shared_ptr<QObject> getQConfig(
+    static std::shared_ptr<QWidget> getQConfig(
         const ComponentInterface::ComponentProperties& sp, const std::map<QString, QVariant>& properties)
     {
-        std::shared_ptr<QObject> q = std::make_shared<QObject>();
+        std::shared_ptr<QWidget> q = std::make_shared<QWidget>();
 
         QStringList props;
         for (auto& p : sp) {
-            if (std::get<2>(p)) {
+            if (ComponentInterface::propertyEditability(p)) {
                 // property editable
-                QString propName = std::get<0>(p);
+                const QString& propName = ComponentInterface::propertyName(p);
                 props.push_back(propName);
                 q->setProperty(propName.toStdString().c_str(), properties.at(propName));
             }
@@ -31,13 +31,13 @@ public:
         return q;
     }
 
-    static void setQConfig(const QObject& qobject, const ComponentInterface::ComponentProperties& sp,
+    static void setQConfig(const QWidget& qobject, const ComponentInterface::ComponentProperties& sp,
         std::map<QString, QVariant>& properties)
     {
         for (auto& p : sp) {
-            QString propName = std::get<0>(p);
+            const QString& propName = ComponentInterface::propertyName(p);
             QVariant v = qobject.property(propName.toStdString().c_str());
-            if (v.isValid() && v.type() == std::get<1>(p)) {
+            if (v.isValid() && v.type() == ComponentInterface::propertyType(p)) {
                 properties[propName] = v;
             }
         }

--- a/src/common/confighelpers.h
+++ b/src/common/confighelpers.h
@@ -31,7 +31,7 @@ public:
                 if (fun) {
                     w = fun();
                 } else {
-                    w = new PropertyFieldPath();
+                    w = new PropertyFieldText();
                 }
 
                 w->setParent(q.get());

--- a/src/common/confighelpers.h
+++ b/src/common/confighelpers.h
@@ -2,8 +2,8 @@
 #define SRC_COMMON_CONFIGHELPERS_H_
 
 #include "componentinterface.h"
-#include <QWidget>
 #include <QVariant>
+#include <QWidget>
 
 #include <map>
 #include <memory>
@@ -23,6 +23,13 @@ public:
                 const QString& propName = ComponentInterface::propertyName(p);
                 props.push_back(propName);
                 q->setProperty(propName.toStdString().c_str(), properties.at(propName));
+
+                auto&& fun = ComponentInterface::propertyEditField(p);
+                if (fun) {
+                    QWidget* w = fun();
+                    w->setParent(q.get());
+                    w->setObjectName(propName + "Widget");
+                }
             }
         }
 

--- a/src/common/confighelpers.h
+++ b/src/common/confighelpers.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <memory>
+#include <propertyfields.h>
 
 class configHelpers {
 
@@ -25,11 +26,16 @@ public:
                 q->setProperty(propName.toStdString().c_str(), properties.at(propName));
 
                 auto&& fun = ComponentInterface::propertyEditField(p);
+                QWidget* w;
+
                 if (fun) {
-                    QWidget* w = fun();
-                    w->setParent(q.get());
-                    w->setObjectName(propName + "Widget");
+                    w = fun();
+                } else {
+                    w = new PropertyTextEdit();
                 }
+
+                w->setParent(q.get());
+                w->setObjectName(propName + "Widget");
             }
         }
 

--- a/src/common/confighelpers.h
+++ b/src/common/confighelpers.h
@@ -25,13 +25,13 @@ public:
                 props.push_back(propName);
                 q->setProperty(propName.toStdString().c_str(), properties.at(propName));
 
-                auto&& fun = ComponentInterface::propertyEditField(p);
+                auto&& fun = ComponentInterface::propertyField(p);
                 QWidget* w;
 
                 if (fun) {
                     w = fun();
                 } else {
-                    w = new PropertyTextEdit();
+                    w = new PropertyFieldPath();
                 }
 
                 w->setParent(q.get());

--- a/src/common/propertyfields.h
+++ b/src/common/propertyfields.h
@@ -1,0 +1,28 @@
+#ifndef __PROPERTYFIELDS_H
+#define __PROPERTYFIELDS_H
+
+#include <QLineEdit>
+
+struct PropertyFieldInterface {
+    virtual void setPropText(const QString& text) = 0;
+    virtual QString propText() = 0;
+};
+
+struct PropertyTextEdit : public QLineEdit, PropertyFieldInterface {
+    PropertyTextEdit()
+    {
+        setFrame(false);
+    }
+
+    void setPropText(const QString& text) override
+    {
+        setText(text);
+    }
+
+    QString propText() override
+    {
+        return text();
+    }
+};
+
+#endif /* !__PROPERTYFIELDS_H */

--- a/src/common/propertyfields.h
+++ b/src/common/propertyfields.h
@@ -1,6 +1,7 @@
 #ifndef __PROPERTYFIELDS_H
 #define __PROPERTYFIELDS_H
 
+#include <QComboBox>
 #include <QFileDialog>
 #include <QHBoxLayout>
 #include <QIntValidator>
@@ -81,4 +82,42 @@ private:
     const bool _folderOnly;
 };
 
+class PropertyFieldCombo : public PropertyField {
+    Q_OBJECT
+
+public:
+    PropertyFieldCombo()
+    {
+        setLayout(new QHBoxLayout);
+        layout()->setContentsMargins(0, 0, 0, 0);
+        _cb = new QComboBox();
+        _cb->setFrame(false);
+        _cb->setEditable(true);
+        layout()->addWidget(_cb);
+        connect(_cb, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged), this,
+            &PropertyFieldCombo::currentTextChanged);
+    }
+
+    void setPropText(const QString& text) override
+    {
+        _cb->setCurrentText(text);
+    }
+
+    QString propText() override
+    {
+        return _cb->currentText();
+    }
+
+    void addItems(const QStringList& list)
+    {
+        _cb->clear();
+        _cb->addItems(list);
+    }
+
+signals:
+    void currentTextChanged(const QString& text);
+
+private:
+    QComboBox* _cb;
+};
 #endif /* !__PROPERTYFIELDS_H */

--- a/src/common/propertyfields.h
+++ b/src/common/propertyfields.h
@@ -1,28 +1,84 @@
 #ifndef __PROPERTYFIELDS_H
 #define __PROPERTYFIELDS_H
 
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QIntValidator>
 #include <QLineEdit>
+#include <QPushButton>
 
-struct PropertyFieldInterface {
+struct PropertyField : public QWidget {
     virtual void setPropText(const QString& text) = 0;
     virtual QString propText() = 0;
 };
 
-struct PropertyTextEdit : public QLineEdit, PropertyFieldInterface {
-    PropertyTextEdit()
+struct PropertyFieldText : public PropertyField {
+    PropertyFieldText(bool numberOnly = false)
+        : _numberOnly(numberOnly)
     {
-        setFrame(false);
+        setLayout(new QHBoxLayout);
+        layout()->setContentsMargins(0, 0, 0, 0);
+        _le = new QLineEdit();
+        _le->setFrame(false);
+        layout()->addWidget(_le);
+
+        if (_numberOnly) {
+            _le->setValidator(new QIntValidator(_le));
+        }
     }
 
     void setPropText(const QString& text) override
     {
-        setText(text);
+        _le->setText(text);
     }
 
     QString propText() override
     {
-        return text();
+        return _le->text();
     }
+
+protected:
+    QLineEdit* _le;
+
+private:
+    const bool _numberOnly;
+};
+
+struct PropertyFieldPath : public PropertyFieldText {
+    PropertyFieldPath(bool folderOnly = false)
+        : _folderOnly(folderOnly)
+    {
+        _pb = new QPushButton();
+        _pb->setText("...");
+        _pb->setFixedSize(24, 24);
+        _pb->setFlat(true);
+        _pb->setProperty("type", "PropertyFieldPath");
+        layout()->addWidget(_pb);
+
+        connect(_pb, &QPushButton::pressed, [&] {
+            QString path;
+            QString currPath = QFileInfo(_le->text()).path();
+
+            if (currPath.length() == 0) {
+                currPath = QDir::homePath();
+            }
+
+            if (_folderOnly) {
+                path = QFileDialog::getExistingDirectory(
+                    this, "Select directory", currPath, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+            } else {
+                path = QFileDialog::getOpenFileName(this, "Select file", currPath);
+            }
+
+            if (path.length() > 0) {
+                _le->setText(path);
+            }
+        });
+    }
+
+private:
+    QPushButton* _pb;
+    const bool _folderOnly;
 };
 
 #endif /* !__PROPERTYFIELDS_H */

--- a/src/components/candevice/candevice.cpp
+++ b/src/components/candevice/candevice.cpp
@@ -132,14 +132,14 @@ QJsonObject CanDevice::getConfig() const
     return config;
 }
 
-void CanDevice::setConfig(const QObject& qobject)
+void CanDevice::setConfig(const QWidget& qobject)
 {
     Q_D(CanDevice);
 
     configHelpers::setQConfig(qobject, getSupportedProperties(), d->_props);
 }
 
-std::shared_ptr<QObject> CanDevice::getQConfig() const
+std::shared_ptr<QWidget> CanDevice::getQConfig() const
 {
     const Q_D(CanDevice);
 

--- a/src/components/candevice/candevice.h
+++ b/src/components/candevice/candevice.h
@@ -2,7 +2,7 @@
 #define __CANDEVICE_H
 
 #include <QScopedPointer>
-#include <QtCore/QObject>
+#include <QWidget>
 #include <componentinterface.h>
 #include <context.h>
 
@@ -43,7 +43,7 @@ public:
     /**
      *  @see ComponentInterface
      */
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
 
     /**
     *   @see ComponentInterface
@@ -53,7 +53,7 @@ public:
     /**
     *   @see ComponentInterface
     */
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
 
     /**
     *   @see ComponentInterface

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -35,7 +35,7 @@ public:
     bool restoreConfiguration(const QJsonObject& json)
     {
         for (const auto& p : _supportedProps) {
-            QString propName = std::get<0>(p);
+            QString propName = ComponentInterface::propertyName(p);
             if (json.contains(propName))
                 _props[propName] = json[propName].toVariant();
         }
@@ -80,10 +80,10 @@ public:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty,  QVariant::String, true),
-            std::make_tuple(_backendProperty, QVariant::String, true),
-            std::make_tuple(_interfaceProperty, QVariant::String, true),
-            std::make_tuple(_configProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty,  QVariant::String, true, nullptr),
+            std::make_tuple(_backendProperty, QVariant::String, true, nullptr),
+            std::make_tuple(_interfaceProperty, QVariant::String, true, nullptr),
+            std::make_tuple(_configProperty, QVariant::String, true, nullptr)
     };
     // clang-format on
 
@@ -93,7 +93,7 @@ private:
     void initProps()
     {
         for (const auto& p : _supportedProps) {
-            _props[std::get<0>(p)];
+            _props[ComponentInterface::propertyName(p)];
         }
     }
 

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -78,12 +78,15 @@ public:
     const QString _interfaceProperty = "interface";
     const QString _configProperty = "configuration";
 
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty,  QVariant::String, true, nullptr),
-            std::make_tuple(_backendProperty, QVariant::String, true, nullptr),
-            std::make_tuple(_interfaceProperty, QVariant::String, true, nullptr),
-            std::make_tuple(_configProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty,  QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_backendProperty, QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_interfaceProperty, QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_configProperty, QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -89,7 +89,9 @@ public:
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
             std::make_tuple(_nameProperty,  QVariant::String, true, cf(nullptr)),
+
 #if QT_VERSION >= 0x050900
+
             std::make_tuple(_backendProperty,  QVariant::String, true, cf([this] {
                     auto *p = new PropertyFieldCombo();
                     p->addItems(QCanBus::instance()->plugins());

--- a/src/components/candevice/candevice_p.h
+++ b/src/components/candevice/candevice_p.h
@@ -105,7 +105,7 @@ public:
 
                     // Connection needs to be destroyed manually. We expect to have only one such conn at a time
                     disconnect(_prevConn);
-                    _prevConn = connect(this, &CanDevicePrivate::backendChanged, [this, p](const QString& backend){
+                    _prevConn = connect(this, &CanDevicePrivate::backendChanged, [p](const QString& backend){
                             QString errorString;
                             const QList<QCanBusDeviceInfo> devices = QCanBus::instance()->availableDevices(
                                 backend, &errorString);

--- a/src/components/canload/canload.cpp
+++ b/src/components/canload/canload.cpp
@@ -31,7 +31,7 @@ void CanLoad::setConfig(const QJsonObject& json)
     d->setSettings(json);
 }
 
-void CanLoad::setConfig(const QObject& qobject)
+void CanLoad::setConfig(const QWidget& qobject)
 {
     Q_D(CanLoad);
 
@@ -46,7 +46,7 @@ QJsonObject CanLoad::getConfig() const
     return d_ptr->getSettings();
 }
 
-std::shared_ptr<QObject> CanLoad::getQConfig() const
+std::shared_ptr<QWidget> CanLoad::getQConfig() const
 {
     const Q_D(CanLoad);
 

--- a/src/components/canload/canload.h
+++ b/src/components/canload/canload.h
@@ -1,7 +1,7 @@
 #ifndef CANLOAD_H
 #define CANLOAD_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -23,9 +23,9 @@ public:
 
     QWidget* mainWidget() override;
     void setConfig(const QJsonObject& json) override;
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
     QJsonObject getConfig() const override;
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
     void configChanged() override;
     bool mainWidgetDocked() const override;
     ComponentInterface::ComponentProperties getSupportedProperties() const override;

--- a/src/components/canload/canload_p.cpp
+++ b/src/components/canload/canload_p.cpp
@@ -22,7 +22,7 @@ CanLoadPrivate::CanLoadPrivate(CanLoad* q, CanLoadCtx&& ctx)
 void CanLoadPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[std::get<0>(p)];
+        _props[ComponentInterface::propertyName(p)];
     }
 
     // Default value
@@ -40,7 +40,7 @@ QJsonObject CanLoadPrivate::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {
-        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
+        json[p.first] = QJsonValue::fromVariant(p.second);
     }
 
     return json;
@@ -49,7 +49,7 @@ QJsonObject CanLoadPrivate::getSettings()
 void CanLoadPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        QString propName = std::get<0>(p);
+        QString propName = ComponentInterface::propertyName(p);
         if (json.contains(propName))
             _props[propName] = json[propName].toVariant();
     }

--- a/src/components/canload/canload_p.h
+++ b/src/components/canload/canload_p.h
@@ -2,7 +2,7 @@
 #define CANLOAD_P_H
 
 #include "canload.h"
-#include <QtCore/QObject>
+#include <QObject>
 #include <memory>
 #include <QTimer>
 
@@ -38,9 +38,9 @@ private:
     CanLoad* q_ptr;
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true),
-            std::make_tuple(_bitrateProperty, QVariant::String, true),
-            std::make_tuple(_periodProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr),
+            std::make_tuple(_bitrateProperty, QVariant::String, true, nullptr),
+            std::make_tuple(_periodProperty, QVariant::String, true, nullptr)
     };
     // clang-format on
 };

--- a/src/components/canload/canload_p.h
+++ b/src/components/canload/canload_p.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QTimer>
 #include <memory>
+#include <propertyfields.h>
 
 class CanLoad;
 
@@ -43,8 +44,8 @@ private:
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
             std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr)),
-            std::make_tuple(_bitrateProperty, QVariant::String, true, cf(nullptr)),
-            std::make_tuple(_periodProperty, QVariant::String, true, cf(nullptr))
+            std::make_tuple(_bitrateProperty, QVariant::String, true, cf([] { return new PropertyFieldText(true); } )),
+            std::make_tuple(_periodProperty, QVariant::String, true, cf([] { return new PropertyFieldText(true); } ))
     };
     // clang-format on
 };

--- a/src/components/canload/canload_p.h
+++ b/src/components/canload/canload_p.h
@@ -3,8 +3,8 @@
 
 #include "canload.h"
 #include <QObject>
-#include <memory>
 #include <QTimer>
+#include <memory>
 
 class CanLoad;
 
@@ -36,11 +36,15 @@ public:
 
 private:
     CanLoad* q_ptr;
+
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr),
-            std::make_tuple(_bitrateProperty, QVariant::String, true, nullptr),
-            std::make_tuple(_periodProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_bitrateProperty, QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_periodProperty, QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 };

--- a/src/components/canload/tests/canload_test.cpp
+++ b/src/components/canload/tests/canload_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Stubbed methods", "[canload]")
 TEST_CASE("setConfig - qobj", "[canload]")
 {
     CanLoad c;
-    QObject obj;
+    QWidget obj;
 
     obj.setProperty("name", "Test Name");
     obj.setProperty("period [ms]", "1111");
@@ -54,20 +54,20 @@ TEST_CASE("getSupportedProperties", "[canload]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("period [ms]", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("period [ms]", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("bitrate [bps]", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("bitrate [bps]", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
         == std::end(props));
 }
 
 TEST_CASE("start/stop - correct timings", "[canload]")
 {
     CanLoad c;
-    QObject obj;
+    QWidget obj;
     QSignalSpy spy(&c, &CanLoad::currentLoad);
     QCanBusFrame frame;
     frame.setFrameId(0x11);

--- a/src/components/canload/tests/canload_test.cpp
+++ b/src/components/canload/tests/canload_test.cpp
@@ -54,14 +54,22 @@ TEST_CASE("getSupportedProperties", "[canload]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("period [ms]", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("bitrate [bps]", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
-        == std::end(props));
+    REQUIRE(props.size() == 3);
+
+    REQUIRE(ComponentInterface::propertyName(props[0]) == "name");
+    REQUIRE(ComponentInterface::propertyType(props[0]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[0]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[0]) == nullptr);
+
+    REQUIRE(ComponentInterface::propertyName(props[1]) == "bitrate [bps]");
+    REQUIRE(ComponentInterface::propertyType(props[1]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[1]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[1]) != nullptr);
+
+    REQUIRE(ComponentInterface::propertyName(props[2]) == "period [ms]");
+    REQUIRE(ComponentInterface::propertyType(props[2]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[2]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[2]) != nullptr);
 }
 
 TEST_CASE("start/stop - correct timings", "[canload]")

--- a/src/components/canrawfilter/canrawfilter.cpp
+++ b/src/components/canrawfilter/canrawfilter.cpp
@@ -32,7 +32,7 @@ void CanRawFilter::setConfig(const QJsonObject& json)
     d->setSettings(json);
 }
 
-void CanRawFilter::setConfig(const QObject& qobject)
+void CanRawFilter::setConfig(const QWidget& qobject)
 {
     Q_D(CanRawFilter);
 
@@ -44,7 +44,7 @@ QJsonObject CanRawFilter::getConfig() const
     return d_ptr->getSettings();
 }
 
-std::shared_ptr<QObject> CanRawFilter::getQConfig() const
+std::shared_ptr<QWidget> CanRawFilter::getQConfig() const
 {
     const Q_D(CanRawFilter);
 

--- a/src/components/canrawfilter/canrawfilter.h
+++ b/src/components/canrawfilter/canrawfilter.h
@@ -1,7 +1,7 @@
 #ifndef CANRAWFILTER_H
 #define CANRAWFILTER_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -24,9 +24,9 @@ public:
 
     QWidget* mainWidget() override;
     void setConfig(const QJsonObject& json) override;
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
     QJsonObject getConfig() const override;
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
     void configChanged() override;
     bool mainWidgetDocked() const override;
     ComponentInterface::ComponentProperties getSupportedProperties() const override;

--- a/src/components/canrawfilter/canrawfilter_p.cpp
+++ b/src/components/canrawfilter/canrawfilter_p.cpp
@@ -35,7 +35,7 @@ CanRawFilterPrivate::CanRawFilterPrivate(CanRawFilter* q, CanRawFilterCtx&& ctx)
 void CanRawFilterPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[std::get<0>(p)];
+        _props[ComponentInterface::propertyName(p)];
     }
 }
 
@@ -110,7 +110,7 @@ CanRawFilterGuiInt::AcceptList_t CanRawFilterPrivate::getAcceptList(const QJsonO
 void CanRawFilterPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        QString propName = std::get<0>(p);
+        QString propName = ComponentInterface::propertyName(p);
         if (json.contains(propName))
             _props[propName] = json[propName].toVariant();
     }

--- a/src/components/canrawfilter/canrawfilter_p.h
+++ b/src/components/canrawfilter/canrawfilter_p.h
@@ -39,7 +39,7 @@ private:
     const QString _nameProperty = "name";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
     };
     // clang-format on
 };

--- a/src/components/canrawfilter/canrawfilter_p.h
+++ b/src/components/canrawfilter/canrawfilter_p.h
@@ -37,9 +37,13 @@ private:
     CanRawFilterGuiInt::AcceptList_t _txAcceptList;
     CanRawFilter* q_ptr;
     const QString _nameProperty = "name";
+
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 };

--- a/src/components/canrawfilter/tests/canrawfilter_test.cpp
+++ b/src/components/canrawfilter/tests/canrawfilter_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Stubbed methods", "[canrawfilter]")
 TEST_CASE("setConfig - qobj", "[canrawfilter]")
 {
     CanRawFilter c;
-    QObject obj;
+    QWidget obj;
 
     obj.setProperty("name", "Test Name");
 
@@ -104,9 +104,9 @@ TEST_CASE("getSupportedProperties", "[canrawfilter]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
         == std::end(props));
 }
 

--- a/src/components/canrawlogger/canrawlogger.cpp
+++ b/src/components/canrawlogger/canrawlogger.cpp
@@ -30,7 +30,7 @@ void CanRawLogger::setConfig(const QJsonObject& json)
     d->setSettings(json);
 }
 
-void CanRawLogger::setConfig(const QObject& qobject)
+void CanRawLogger::setConfig(const QWidget& qobject)
 {
     Q_D(CanRawLogger);
 
@@ -42,7 +42,7 @@ QJsonObject CanRawLogger::getConfig() const
     return d_ptr->getSettings();
 }
 
-std::shared_ptr<QObject> CanRawLogger::getQConfig() const
+std::shared_ptr<QWidget> CanRawLogger::getQConfig() const
 {
     const Q_D(CanRawLogger);
 

--- a/src/components/canrawlogger/canrawlogger.h
+++ b/src/components/canrawlogger/canrawlogger.h
@@ -1,7 +1,7 @@
 #ifndef CANRAWLOGGER_H
 #define CANRAWLOGGER_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -23,9 +23,9 @@ public:
 
     QWidget* mainWidget() override;
     void setConfig(const QJsonObject& json) override;
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
     QJsonObject getConfig() const override;
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
     void configChanged() override;
     bool mainWidgetDocked() const override;
     ComponentInterface::ComponentProperties getSupportedProperties() const override;

--- a/src/components/canrawlogger/canrawlogger_p.cpp
+++ b/src/components/canrawlogger/canrawlogger_p.cpp
@@ -12,7 +12,7 @@ CanRawLoggerPrivate::CanRawLoggerPrivate(CanRawLogger* q, CanRawLoggerCtx&& ctx)
 void CanRawLoggerPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[std::get<0>(p)];
+        _props[ComponentInterface::propertyName(p)];
     }
 
     _props[_dirProperty] = ".";
@@ -28,7 +28,7 @@ QJsonObject CanRawLoggerPrivate::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {
-        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
+        json[p.first] = QJsonValue::fromVariant(p.second);
     }
 
     return json;
@@ -37,7 +37,7 @@ QJsonObject CanRawLoggerPrivate::getSettings()
 void CanRawLoggerPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        QString propName = std::get<0>(p);
+        const QString &propName = ComponentInterface::propertyName(p);
         if (json.contains(propName))
             _props[propName] = json[propName].toVariant();
     }

--- a/src/components/canrawlogger/canrawlogger_p.h
+++ b/src/components/canrawlogger/canrawlogger_p.h
@@ -35,10 +35,14 @@ private:
     CanRawLogger* q_ptr;
     const QString _nameProperty = "name";
     const QString _dirProperty = "directory";
+
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty,  QVariant::String, true, nullptr),
-            std::make_tuple(_dirProperty,  QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty,  QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_dirProperty,  QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 };

--- a/src/components/canrawlogger/canrawlogger_p.h
+++ b/src/components/canrawlogger/canrawlogger_p.h
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QtCore/QObject>
 #include <memory>
+#include <propertyfields.h>
 
 class CanRawLogger;
 
@@ -42,7 +43,7 @@ private:
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
             std::make_tuple(_nameProperty,  QVariant::String, true, cf(nullptr)),
-            std::make_tuple(_dirProperty,  QVariant::String, true, cf(nullptr))
+            std::make_tuple(_dirProperty,  QVariant::String, true, cf([] { return new PropertyFieldPath(true); } ))
     };
     // clang-format on
 };

--- a/src/components/canrawlogger/canrawlogger_p.h
+++ b/src/components/canrawlogger/canrawlogger_p.h
@@ -37,8 +37,8 @@ private:
     const QString _dirProperty = "directory";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty,  QVariant::String, true),
-            std::make_tuple(_dirProperty,  QVariant::String, true)
+            std::make_tuple(_nameProperty,  QVariant::String, true, nullptr),
+            std::make_tuple(_dirProperty,  QVariant::String, true, nullptr)
     };
     // clang-format on
 };

--- a/src/components/canrawlogger/tests/canrawlogger_test.cpp
+++ b/src/components/canrawlogger/tests/canrawlogger_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Stubbed methods", "[canrawlogger]")
 TEST_CASE("setConfig - qobj", "[canrawlogger]")
 {
     CanRawLogger c;
-    QObject obj;
+    QWidget obj;
 
     obj.setProperty("name", "Test Name");
 
@@ -71,18 +71,18 @@ TEST_CASE("getSupportedProperties", "[canrawlogger]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("directory", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("directory", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
         == std::end(props));
 }
 
 TEST_CASE("logging - directories", "[canrawlogger]")
 {
     CanRawLogger c;
-    QObject obj;
+    QWidget obj;
     QString dirName = "dummy";
     QDir dir;
 
@@ -116,7 +116,7 @@ TEST_CASE("logging - directories", "[canrawlogger]")
 TEST_CASE("logging - filenames", "[canrawlogger]")
 {
     CanRawLogger c1, c2, c3;
-    QObject obj;
+    QWidget obj;
     QString dirName = "filename_test";
     QDir dir;
 
@@ -179,7 +179,7 @@ static uint32_t loadTraceFile(const QString& filename)
 TEST_CASE("logging - send/receive", "[canrawlogger]")
 {
     CanRawLogger c;
-    QObject obj;
+    QWidget obj;
     QCanBusFrame frame;
     QString dirName = "filename_test";
     QDir dir;
@@ -225,7 +225,7 @@ TEST_CASE("logging - send/receive", "[canrawlogger]")
 TEST_CASE("logging - send/receive, removed file", "[canrawlogger]")
 {
     CanRawLogger c;
-    QObject obj;
+    QWidget obj;
     QCanBusFrame frame;
     QString dirName = "filename_test";
     QDir dir;
@@ -265,7 +265,7 @@ TEST_CASE("logging - send/receive, removed file", "[canrawlogger]")
 TEST_CASE("logging - send/receive while stopped", "[canrawlogger]")
 {
     CanRawLogger c;
-    QObject obj;
+    QWidget obj;
     QCanBusFrame frame;
     QString dirName = "filename_test";
     QDir dir;

--- a/src/components/canrawlogger/tests/canrawlogger_test.cpp
+++ b/src/components/canrawlogger/tests/canrawlogger_test.cpp
@@ -71,12 +71,17 @@ TEST_CASE("getSupportedProperties", "[canrawlogger]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("directory", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
-        == std::end(props));
+    REQUIRE(props.size() == 2);
+
+    REQUIRE(ComponentInterface::propertyName(props[0]) == "name");
+    REQUIRE(ComponentInterface::propertyType(props[0]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[0]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[0]) == nullptr);
+
+    REQUIRE(ComponentInterface::propertyName(props[1]) == "directory");
+    REQUIRE(ComponentInterface::propertyType(props[1]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[1]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[1]) != nullptr);
 }
 
 TEST_CASE("logging - directories", "[canrawlogger]")
@@ -215,7 +220,7 @@ TEST_CASE("logging - send/receive", "[canrawlogger]")
     c.frameReceived(frame);
     c.frameReceived(frame);
     c.frameReceived(frame);
-    
+
     fileList = dir.entryList({ "*" });
     CHECK(fileList.size() == 3);
     msgCnt = loadTraceFile(dirName + "/" + fileList[2]);

--- a/src/components/canrawplayer/canrawplayer.cpp
+++ b/src/components/canrawplayer/canrawplayer.cpp
@@ -30,7 +30,7 @@ void CanRawPlayer::setConfig(const QJsonObject& json)
     d->setSettings(json);
 }
 
-void CanRawPlayer::setConfig(const QObject& qobject)
+void CanRawPlayer::setConfig(const QWidget& qobject)
 {
     Q_D(CanRawPlayer);
 
@@ -42,7 +42,7 @@ QJsonObject CanRawPlayer::getConfig() const
     return d_ptr->getSettings();
 }
 
-std::shared_ptr<QObject> CanRawPlayer::getQConfig() const
+std::shared_ptr<QWidget> CanRawPlayer::getQConfig() const
 {
     const Q_D(CanRawPlayer);
 

--- a/src/components/canrawplayer/canrawplayer.h
+++ b/src/components/canrawplayer/canrawplayer.h
@@ -1,7 +1,7 @@
 #ifndef CANRAWPLAYER_H
 #define CANRAWPLAYER_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -23,9 +23,9 @@ public:
 
     QWidget* mainWidget() override;
     void setConfig(const QJsonObject& json) override;
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
     QJsonObject getConfig() const override;
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
     void configChanged() override;
     bool mainWidgetDocked() const override;
     ComponentInterface::ComponentProperties getSupportedProperties() const override;

--- a/src/components/canrawplayer/canrawplayer_p.cpp
+++ b/src/components/canrawplayer/canrawplayer_p.cpp
@@ -22,7 +22,7 @@ CanRawPlayerPrivate::CanRawPlayerPrivate(CanRawPlayer* q, CanRawPlayerCtx&& ctx)
 void CanRawPlayerPrivate::initProps()
 {
     for (const auto& p : _supportedProps) {
-        _props[std::get<0>(p)];
+        _props[ComponentInterface::propertyName(p)];
     }
     
     _props[_tickProperty] = _tick;
@@ -38,7 +38,7 @@ QJsonObject CanRawPlayerPrivate::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {
-        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
+        json[p.first] = QJsonValue::fromVariant(p.second);
     }
 
     return json;
@@ -47,7 +47,7 @@ QJsonObject CanRawPlayerPrivate::getSettings()
 void CanRawPlayerPrivate::setSettings(const QJsonObject& json)
 {
     for (const auto& p : _supportedProps) {
-        QString propName = std::get<0>(p);
+        QString propName = ComponentInterface::propertyName(p);
         if (json.contains(propName))
             _props[propName] = json[propName].toVariant();
     }

--- a/src/components/canrawplayer/canrawplayer_p.h
+++ b/src/components/canrawplayer/canrawplayer_p.h
@@ -44,11 +44,15 @@ private:
     uint32_t _frameNdx;
     uint32_t _ticks;
     QTimer _timer;
+
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr),
-            std::make_tuple(_fileProperty, QVariant::String, true, nullptr),
-            std::make_tuple(_tickProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_fileProperty, QVariant::String, true, cf(nullptr)),
+            std::make_tuple(_tickProperty, QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 };

--- a/src/components/canrawplayer/canrawplayer_p.h
+++ b/src/components/canrawplayer/canrawplayer_p.h
@@ -46,9 +46,9 @@ private:
     QTimer _timer;
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true),
-            std::make_tuple(_fileProperty, QVariant::String, true),
-            std::make_tuple(_tickProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr),
+            std::make_tuple(_fileProperty, QVariant::String, true, nullptr),
+            std::make_tuple(_tickProperty, QVariant::String, true, nullptr)
     };
     // clang-format on
 };

--- a/src/components/canrawplayer/canrawplayer_p.h
+++ b/src/components/canrawplayer/canrawplayer_p.h
@@ -6,6 +6,7 @@
 #include <QtCore/QTimer>
 #include <memory>
 #include "canrawplayer.h"
+#include <propertyfields.h>
 
 class CanRawPlayer;
 
@@ -51,8 +52,8 @@ private:
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
             std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr)),
-            std::make_tuple(_fileProperty, QVariant::String, true, cf(nullptr)),
-            std::make_tuple(_tickProperty, QVariant::String, true, cf(nullptr))
+            std::make_tuple(_fileProperty, QVariant::String, true, cf([] { return new PropertyFieldPath; } )),
+            std::make_tuple(_tickProperty, QVariant::String, true, cf([] { return new PropertyFieldText(true); } ))
     };
     // clang-format on
 };

--- a/src/components/canrawplayer/tests/canrawplayer_test.cpp
+++ b/src/components/canrawplayer/tests/canrawplayer_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Stubbed methods", "[canrawplayer]")
 TEST_CASE("setConfig - qobj", "[canrawplayer]")
 {
     CanRawPlayer c;
-    QObject obj;
+    QWidget obj;
 
     obj.setProperty("name", "Test Name");
 
@@ -58,7 +58,7 @@ TEST_CASE("getQConfig", "[canrawplayer]")
 TEST_CASE("configChanged", "[canrawplayer]")
 {
     CanRawPlayer c;
-    QObject obj;
+    QWidget obj;
     std::string filename = "wrongFile";
 
     c.configChanged();
@@ -80,13 +80,13 @@ TEST_CASE("getSupportedProperties", "[canrawplayer]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("file", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("file", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("timer tick [ms]", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("timer tick [ms]", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
         == std::end(props));
 }
 
@@ -137,7 +137,7 @@ TEST_CASE("Send test", "[canrawplayer]")
     using namespace std::chrono_literals;
 
     CanRawPlayer c;
-    QObject props;
+    QWidget props;
     QSignalSpy sendSpy(&c, &CanRawPlayer::sendFrame);
     QThread th;
 
@@ -165,7 +165,7 @@ TEST_CASE("Send test 2", "[canrawplayer]")
     using namespace std::chrono_literals;
 
     CanRawPlayer c;
-    QObject props;
+    QWidget props;
     QSignalSpy sendSpy(&c, &CanRawPlayer::sendFrame);
     QThread th;
 

--- a/src/components/canrawplayer/tests/canrawplayer_test.cpp
+++ b/src/components/canrawplayer/tests/canrawplayer_test.cpp
@@ -80,14 +80,22 @@ TEST_CASE("getSupportedProperties", "[canrawplayer]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("file", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("timer tick [ms]", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
-        == std::end(props));
+    REQUIRE(props.size() == 3);
+
+    REQUIRE(ComponentInterface::propertyName(props[0]) == "name");
+    REQUIRE(ComponentInterface::propertyType(props[0]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[0]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[0]) == nullptr);
+
+    REQUIRE(ComponentInterface::propertyName(props[1]) == "file");
+    REQUIRE(ComponentInterface::propertyType(props[1]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[1]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[1]) != nullptr);
+
+    REQUIRE(ComponentInterface::propertyName(props[2]) == "timer tick [ms]");
+    REQUIRE(ComponentInterface::propertyType(props[2]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[2]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[2]) != nullptr);
 }
 
 static QString createTestFile()

--- a/src/components/canrawsender/canrawsender.cpp
+++ b/src/components/canrawsender/canrawsender.cpp
@@ -17,14 +17,14 @@ CanRawSender::~CanRawSender()
 {
 }
 
-void CanRawSender::setConfig(const QObject& qobject)
+void CanRawSender::setConfig(const QWidget& qobject)
 {
     Q_D(CanRawSender);
 
     configHelpers::setQConfig(qobject, getSupportedProperties(), d->_props);
 }
 
-std::shared_ptr<QObject> CanRawSender::getQConfig() const
+std::shared_ptr<QWidget> CanRawSender::getQConfig() const
 {
     const Q_D(CanRawSender);
 

--- a/src/components/canrawsender/canrawsender.h
+++ b/src/components/canrawsender/canrawsender.h
@@ -1,7 +1,7 @@
 #ifndef CANRAWSENDER_H
 #define CANRAWSENDER_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -35,7 +35,7 @@ public:
     /**
      *  @see ComponentInterface
      */
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
 
     /**
     *   @see ComponentInterface
@@ -45,7 +45,7 @@ public:
     /**
     *   @see ComponentInterface
     */
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
 
     /**
     *   @see ComponentInterface

--- a/src/components/canrawsender/canrawsender_p.h
+++ b/src/components/canrawsender/canrawsender_p.h
@@ -126,9 +126,12 @@ private:
 
     const QString _nameProperty = "name";
 
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 };

--- a/src/components/canrawsender/canrawsender_p.h
+++ b/src/components/canrawsender/canrawsender_p.h
@@ -98,7 +98,7 @@ private:
     {
         for (const auto& p: _supportedProps)
         {
-            _props[std::get<0>(p)];
+            _props[ComponentInterface::propertyName(p)];
         }
     }
 
@@ -128,7 +128,7 @@ private:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
     };
     // clang-format on
 };

--- a/src/components/canrawsender/tests/canrawsender_test.cpp
+++ b/src/components/canrawsender/tests/canrawsender_test.cpp
@@ -335,7 +335,7 @@ TEST_CASE("Misc", "[canrawsender]")
 TEST_CASE("setConfig using QObject", "[canrawsender]")
 {
     CanRawSender crs;
-    QObject config;
+    QWidget config;
 
     config.setProperty("name", "CAN1");
     config.setProperty("fake", "unsupported");

--- a/src/components/canrawview/canrawview.cpp
+++ b/src/components/canrawview/canrawview.cpp
@@ -86,14 +86,14 @@ QJsonObject CanRawView::getConfig() const
     return config;
 }
 
-void CanRawView::setConfig(const QObject& qobject)
+void CanRawView::setConfig(const QWidget& qobject)
 {
     Q_D(CanRawView);
 
     configHelpers::setQConfig(qobject, getSupportedProperties(), d->_props);
 }
 
-std::shared_ptr<QObject> CanRawView::getQConfig() const
+std::shared_ptr<QWidget> CanRawView::getQConfig() const
 {
     const Q_D(CanRawView);
 

--- a/src/components/canrawview/canrawview.h
+++ b/src/components/canrawview/canrawview.h
@@ -1,7 +1,7 @@
 #ifndef CANRAWVIEW_H
 #define CANRAWVIEW_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -33,7 +33,7 @@ public:
     /**
      *  @see ComponentInterface
      */
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
 
     /**
     *   @see ComponentInterface
@@ -43,7 +43,7 @@ public:
     /**
     *   @see ComponentInterface
     */
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
 
     /**
     *   @see ComponentInterface

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -352,7 +352,7 @@ private:
     void initProps()
     {
         for (const auto& p : _supportedProps) {
-            _props[std::get<0>(p)];
+            _props[ComponentInterface::propertyName(p)];
         }
     }
 
@@ -442,7 +442,7 @@ private:
 
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
     };
     // clang-format on
 };

--- a/src/components/canrawview/canrawview_p.h
+++ b/src/components/canrawview/canrawview_p.h
@@ -440,9 +440,12 @@ private:
 
     const QString _nameProperty = "name";
 
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr))
     };
     // clang-format on
 };

--- a/src/components/canrawview/tests/canrawview_test.cpp
+++ b/src/components/canrawview/tests/canrawview_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("Sort test", "[canrawview]")
 TEST_CASE("setConfig using QObject", "[canrawview]")
 {
     CanRawView crv;
-    QObject config;
+    QWidget config;
 
     config.setProperty("name", "CAN1");
     config.setProperty("fake", "unsupported");

--- a/src/gui/projectconfig/propertyeditordialog.cpp
+++ b/src/gui/projectconfig/propertyeditordialog.cpp
@@ -11,11 +11,12 @@ PropertyEditorDialog::PropertyEditorDialog(const QString& title, const QWidget& 
     setWindowFlags(Qt::Dialog | Qt::WindowTitleHint);
     _model.setHorizontalHeaderLabels({ "Property", "Value" });
 
-    fillModel(propertySource);
     _ui->tableView->verticalHeader()->hide();
     _ui->tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
     _ui->tableView->horizontalHeader()->setStretchLastSection(true);
     _ui->tableView->setModel(&_model);
+
+    fillModel(propertySource);
 }
 
 PropertyEditorDialog::~PropertyEditorDialog() {}
@@ -58,6 +59,11 @@ void PropertyEditorDialog::fillModel(const QWidget& propsObj)
             _model.appendRow(list);
 
             cds_debug("Adding '{}' to model", p.toStdString());
+
+            QWidget* w = propsObj.findChild<QWidget*>(p + "Widget");
+            if (w) {
+                _ui->tableView->setIndexWidget(_model.index(_model.rowCount() - 1, 1), w);
+            }
         }
     }
 }

--- a/src/gui/projectconfig/propertyeditordialog.cpp
+++ b/src/gui/projectconfig/propertyeditordialog.cpp
@@ -2,7 +2,7 @@
 #include "ui_propertyeditordialog.h"
 #include <log.h>
 
-PropertyEditorDialog::PropertyEditorDialog(const QString& title, const QObject& propertySource, QWidget* parent)
+PropertyEditorDialog::PropertyEditorDialog(const QString& title, const QWidget& propertySource, QWidget* parent)
     : QDialog(parent)
     , _ui(std::make_unique<Ui::PropertyEditorDialog>())
 {
@@ -20,9 +20,9 @@ PropertyEditorDialog::PropertyEditorDialog(const QString& title, const QObject& 
 
 PropertyEditorDialog::~PropertyEditorDialog() {}
 
-std::shared_ptr<QObject> PropertyEditorDialog::properties()
+std::shared_ptr<QWidget> PropertyEditorDialog::properties()
 {
-    std::shared_ptr<QObject> ret = std::make_shared<QObject>();
+    std::shared_ptr<QWidget> ret = std::make_shared<QWidget>();
 
     for (int i = 0; i < _model.rowCount(); ++i) {
         auto&& propName = _model.item(i, 0)->data(Qt::DisplayRole).toString().toStdString();
@@ -35,7 +35,7 @@ std::shared_ptr<QObject> PropertyEditorDialog::properties()
     return ret;
 }
 
-void PropertyEditorDialog::fillModel(const QObject& propsObj)
+void PropertyEditorDialog::fillModel(const QWidget& propsObj)
 {
     auto prop = propsObj.property("exposedProperties");
 

--- a/src/gui/projectconfig/propertyeditordialog.cpp
+++ b/src/gui/projectconfig/propertyeditordialog.cpp
@@ -1,5 +1,6 @@
 #include "propertyeditordialog.h"
 #include "ui_propertyeditordialog.h"
+#include <propertyfields.h>
 #include <log.h>
 
 PropertyEditorDialog::PropertyEditorDialog(const QString& title, const QWidget& propertySource, QWidget* parent)
@@ -52,7 +53,7 @@ void PropertyEditorDialog::fillModel(const QWidget& propsObj)
             QList<QStandardItem*> list;
 
             auto propName = new QStandardItem(p);
-            propName->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+            propName->setFlags(Qt::NoItemFlags);
             list.append(propName);
             list.append(new QStandardItem(propsObj.property(p.toStdString().c_str()).toString()));
 
@@ -60,8 +61,11 @@ void PropertyEditorDialog::fillModel(const QWidget& propsObj)
 
             cds_debug("Adding '{}' to model", p.toStdString());
 
-            QWidget* w = propsObj.findChild<QWidget*>(p + "Widget");
+            auto w = propsObj.findChild<QWidget*>(p + "Widget");
+            //auto pi = propsObj.findChild<PropertyFieldInterface*>(p + "Widget");
+            PropertyFieldInterface *pi = dynamic_cast<PropertyFieldInterface*>(w);
             if (w) {
+                pi->setPropText(propsObj.property(p.toStdString().c_str()).toString());
                 _ui->tableView->setIndexWidget(_model.index(_model.rowCount() - 1, 1), w);
             }
         }

--- a/src/gui/projectconfig/propertyeditordialog.cpp
+++ b/src/gui/projectconfig/propertyeditordialog.cpp
@@ -1,7 +1,7 @@
 #include "propertyeditordialog.h"
 #include "ui_propertyeditordialog.h"
-#include <propertyfields.h>
 #include <log.h>
+#include <propertyfields.h>
 
 PropertyEditorDialog::PropertyEditorDialog(const QString& title, const QWidget& propertySource, QWidget* parent)
     : QDialog(parent)
@@ -28,7 +28,9 @@ std::shared_ptr<QWidget> PropertyEditorDialog::properties()
 
     for (int i = 0; i < _model.rowCount(); ++i) {
         auto&& propName = _model.item(i, 0)->data(Qt::DisplayRole).toString().toStdString();
-        auto&& propVal = _model.item(i, 1)->data(Qt::DisplayRole).toString();
+
+        auto w = static_cast<PropertyField*>(_ui->tableView->indexWidget(_model.index(i, 1)));
+        auto&& propVal = w->propText();
 
         cds_debug("Setting property '{}' = '{}'", propName, propVal.toStdString());
         ret->setProperty(propName.c_str(), propVal);
@@ -61,12 +63,11 @@ void PropertyEditorDialog::fillModel(const QWidget& propsObj)
 
             cds_debug("Adding '{}' to model", p.toStdString());
 
-            auto w = propsObj.findChild<QWidget*>(p + "Widget");
-            //auto pi = propsObj.findChild<PropertyFieldInterface*>(p + "Widget");
-            PropertyFieldInterface *pi = dynamic_cast<PropertyFieldInterface*>(w);
+            auto w = propsObj.findChild<PropertyField*>(p + "Widget");
             if (w) {
-                pi->setPropText(propsObj.property(p.toStdString().c_str()).toString());
-                _ui->tableView->setIndexWidget(_model.index(_model.rowCount() - 1, 1), w);
+                w->setPropText(propsObj.property(p.toStdString().c_str()).toString());
+                auto ndx = _model.index(_model.rowCount() - 1, 1);
+                _ui->tableView->setIndexWidget(ndx, w);
             }
         }
     }

--- a/src/gui/projectconfig/propertyeditordialog.h
+++ b/src/gui/projectconfig/propertyeditordialog.h
@@ -19,16 +19,16 @@ class PropertyEditorDialog : public QDialog {
     Q_OBJECT
 
 public:
-    PropertyEditorDialog(const QString& title, const QObject& propertySource, QWidget* parent = nullptr);
+    PropertyEditorDialog(const QString& title, const QWidget& propertySource, QWidget* parent = nullptr);
     virtual ~PropertyEditorDialog();
 
-    std::shared_ptr<QObject> properties();
+    std::shared_ptr<QWidget> properties();
 
 private:
     std::unique_ptr<Ui::PropertyEditorDialog> _ui;
     QStandardItemModel _model;
 
-    void fillModel(const QObject& propsObj);
+    void fillModel(const QWidget& propsObj);
 };
 
 #endif /* SRC_GUI_PROPERTYEDITORDIALOG_H_ */

--- a/src/gui/projectconfig/tests/projectconfig_test_noqrc.cpp
+++ b/src/gui/projectconfig/tests/projectconfig_test_noqrc.cpp
@@ -29,7 +29,7 @@ TEST_CASE("PropertyEditorDialog", "[projectconfig]")
 
 TEST_CASE("PropertyEditorDialog no exposed props", "[projectconfig]")
 {
-    QObject obj;
+    QWidget obj;
     PropertyEditorDialog dialog("title", obj);
 
     auto props = dialog.properties();

--- a/tools/templategen/main.cpp
+++ b/tools/templategen/main.cpp
@@ -216,9 +216,13 @@ public:
 private:
     {name}* q_ptr;
     const QString _nameProperty = "name";
+
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr))
     }};
     // clang-format on
 }};
@@ -483,9 +487,13 @@ public:
 private:
     {name}* q_ptr;
     const QString _nameProperty = "name";
+
+    // workaround for clang 3.5
+    using cf = ComponentInterface::CustomEditFieldCbk;
+
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
+            std::make_tuple(_nameProperty, QVariant::String, true, cf(nullptr))
     }};
     // clang-format on
 }};

--- a/tools/templategen/main.cpp
+++ b/tools/templategen/main.cpp
@@ -837,10 +837,12 @@ TEST_CASE("getSupportedProperties", "[{nameLower}]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
-        != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
-        == std::end(props));
+    REQUIRE(props.size() == 1);
+
+    REQUIRE(ComponentInterface::propertyName(props[0]) == "name");
+    REQUIRE(ComponentInterface::propertyType(props[0]) == QVariant::String);
+    REQUIRE(ComponentInterface::propertyEditability(props[0]) == true);
+    REQUIRE(ComponentInterface::propertyField(props[0]) == nullptr);
 }}
 
 int main(int argc, char* argv[])

--- a/tools/templategen/main.cpp
+++ b/tools/templategen/main.cpp
@@ -52,7 +52,7 @@ std::string genComponentHdr(const std::string& name)
     return fmt::format(R"(#ifndef {nameUpper}_H
 #define {nameUpper}_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -73,9 +73,9 @@ public:
 
     QWidget* mainWidget() override;
     void setConfig(const QJsonObject& json) override;
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
     QJsonObject getConfig() const override;
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
     void configChanged() override;
     bool mainWidgetDocked() const override;
     ComponentInterface::ComponentProperties getSupportedProperties() const override;
@@ -132,7 +132,7 @@ void {name}::setConfig(const QJsonObject& json)
     d->setSettings(json);
 }}
 
-void {name}::setConfig(const QObject& qobject)
+void {name}::setConfig(const QWidget& qobject)
 {{
     Q_D({name});
 
@@ -144,7 +144,7 @@ QJsonObject {name}::getConfig() const
     return d_ptr->getSettings();
 }}
 
-std::shared_ptr<QObject> {name}::getQConfig() const
+std::shared_ptr<QWidget> {name}::getQConfig() const
 {{
     const Q_D({name});
 
@@ -191,7 +191,6 @@ std::string genPrivateHdr(const std::string& name)
 #define {nameUpper}_P_H
 
 #include "{nameLower}.h"
-#include <QtCore/QObject>
 #include <memory>
 
 class {name};
@@ -219,7 +218,7 @@ private:
     const QString _nameProperty = "name";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            std::make_tuple(_nameProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
     }};
     // clang-format on
 }};
@@ -246,7 +245,7 @@ std::string genPrivateSrc(const std::string& name)
 void {name}Private::initProps()
 {{
     for (const auto& p: _supportedProps) {{
-        _props[std::get<0>(p)];
+        _props[ComponentInterface::propertyName(p)];
     }}
 }}
 
@@ -260,7 +259,7 @@ QJsonObject {name}Private::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {{
-        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
+        json[p.first] = QJsonValue::fromVariant(p.second);
     }}
 
     return json;
@@ -269,7 +268,7 @@ QJsonObject {name}Private::getSettings()
 void {name}Private::setSettings(const QJsonObject& json)
 {{
     for (const auto& p : _supportedProps) {{
-        QString propName = std::get<0>(p);
+        const QString& propName = ComponentInterface::propertyName(p);
         if (json.contains(propName))
             _props[propName] = json[propName].toVariant();
     }}
@@ -316,7 +315,7 @@ std::string genGuiComponentHdr(const std::string& name)
     return fmt::format(R"(#ifndef {nameUpper}_H
 #define {nameUpper}_H
 
-#include <QtCore/QObject>
+#include <QWidget>
 #include <QtCore/QScopedPointer>
 #include <componentinterface.h>
 #include <context.h>
@@ -338,9 +337,9 @@ public:
 
     QWidget* mainWidget() override;
     void setConfig(const QJsonObject& json) override;
-    void setConfig(const QObject& qobject) override;
+    void setConfig(const QWidget& qobject) override;
     QJsonObject getConfig() const override;
-    std::shared_ptr<QObject> getQConfig() const override;
+    std::shared_ptr<QWidget> getQConfig() const override;
     void configChanged() override;
     bool mainWidgetDocked() const override;
     ComponentInterface::ComponentProperties getSupportedProperties() const override;
@@ -398,7 +397,7 @@ void {name}::setConfig(const QJsonObject& json)
     d->setSettings(json);
 }}
 
-void {name}::setConfig(const QObject& qobject)
+void {name}::setConfig(const QWidget& qobject)
 {{
     Q_D({name});
 
@@ -410,7 +409,7 @@ QJsonObject {name}::getConfig() const
     return d_ptr->getSettings();
 }}
 
-std::shared_ptr<QObject> {name}::getQConfig() const
+std::shared_ptr<QWidget> {name}::getQConfig() const
 {{
     const Q_D({name});
 
@@ -457,7 +456,6 @@ std::string genGuiPrivateHdr(const std::string& name)
 
 #include "gui/{nameLower}guiimpl.h"
 #include "{nameLower}.h"
-#include <QtCore/QObject>
 #include <memory>
 
 class {name};
@@ -487,7 +485,7 @@ private:
     const QString _nameProperty = "name";
     // clang-format off
     ComponentInterface::ComponentProperties _supportedProps = {{
-            std::make_tuple(_nameProperty, QVariant::String, true)
+            std::make_tuple(_nameProperty, QVariant::String, true, nullptr)
     }};
     // clang-format on
 }};
@@ -516,7 +514,7 @@ void {name}Private::initProps()
 {{
     for (const auto& p: _supportedProps)
     {{
-        _props[std::get<0>(p)];
+        _props[ComponentInterface::propertyName(p)];
     }}
 }}
 
@@ -530,7 +528,7 @@ QJsonObject {name}Private::getSettings()
     QJsonObject json;
 
     for (const auto& p : _props) {{
-        json[std::get<0>(p)] = QJsonValue::fromVariant(p.second);
+        json[p.first] = QJsonValue::fromVariant(p.second);
     }}
 
     return json;
@@ -539,7 +537,7 @@ QJsonObject {name}Private::getSettings()
 void {name}Private::setSettings(const QJsonObject& json)
 {{
     for (const auto& p : _supportedProps) {{
-        QString propName = std::get<0>(p);
+        const QString& propName = ComponentInterface::propertyName(p);
         if (json.contains(propName))
             _props[propName] = json[propName].toVariant();
     }}
@@ -787,7 +785,7 @@ TEST_CASE("Stubbed methods", "[{nameLower}]")
 TEST_CASE("setConfig - qobj", "[{nameLower}]")
 {{
     {name} c;
-    QObject obj;
+    QWidget obj;
 
     obj.setProperty("name", "Test Name");
 
@@ -831,9 +829,9 @@ TEST_CASE("getSupportedProperties", "[{nameLower}]")
 
     auto props = c.getSupportedProperties();
 
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("name", QVariant::String, true, nullptr))
         != std::end(props));
-    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true))
+    CHECK(std::find(std::begin(props), std::end(props), std::make_tuple("dummy", QVariant::String, true, nullptr))
         == std::end(props));
 }}
 


### PR DESCRIPTION
Add possibility to set custom fields for PropertyEditorDialog. Supported custom fields:
- Standard text line
- Number text line
- File path
- Folder path
- Combo box

CanDevice implements custom combo boxes that enables to select available CanDevice plugins and resulting interfaces (as requested in #142 and #143 ). It's up to certain plugin to properly enumerate CAN interfaces. Not every plugin provides such functionality.

Fixed field's tab focus in PropertyEditorDialog