### PR TITLE
CanRawSender: make sure changes to row are applied

### DIFF
--- a/src/components/canrawsender/newlinemanager.cpp
+++ b/src/components/canrawsender/newlinemanager.cpp
@@ -19,7 +19,7 @@ NewLineManager::NewLineManager(CanRawSender* q, bool _simulationState, NLMFactor
     QRegExp qRegExp("[0-9A-Fa-f]{1,8}");
     _vIdHex = new QRegExpValidator(qRegExp, this);
     _id->init("Id in hex", _vIdHex);
-    _id->textChangedCbk(std::bind(&NewLineManager::SetSendButtonState, this));
+    _id->textChangedCbk(std::bind(&NewLineManager::FrameDataChanged, this));
     _id->editingFinishedCbk([&] {
         QString text = _id->getText();
         bool ok;
@@ -41,7 +41,7 @@ NewLineManager::NewLineManager(CanRawSender* q, bool _simulationState, NLMFactor
     qRegExp.setPattern("[0-9A-Fa-f]{16}");
     _vDataHex = new QRegExpValidator(qRegExp, this);
     _data->init("Data in hex", _vDataHex);
-    _data->textChangedCbk(std::bind(&NewLineManager::SetSendButtonState, this));
+    _data->textChangedCbk(std::bind(&NewLineManager::FrameDataChanged, this));
 
     // Interval
     _interval.reset(mFactory.createLineEdit());
@@ -206,4 +206,15 @@ bool NewLineManager::RestoreLine(QString& id, QString data, QString interval, bo
     }
 
     return true;
+}
+
+void NewLineManager::FrameDataChanged()
+{
+    // Update frame data
+    quint32 id = _id->getText().toUInt(nullptr, 16);
+    _frame.setFrameId(id);
+    _frame.setPayload(QByteArray::fromHex(_data->getText().toUtf8()));
+
+    // Update Send button state
+    SetSendButtonState();
 }

--- a/src/components/canrawsender/newlinemanager.h
+++ b/src/components/canrawsender/newlinemanager.h
@@ -89,6 +89,7 @@ private slots:
     void SetSendButtonState();
     void SendButtonPressed();
     void TimerExpired();
+    void FrameDataChanged();
 };
 
 #endif // NEWLINEMANAGER_H


### PR DESCRIPTION
There is an issue that changes to Id and Data fields doesn't have any
effect until the Send button is toggled. This commit fixes that by
always updating _frame when Id or Data are changed.

Fixes #179

Signed-off-by: Erik Botö <erik.boto@gmail.com>