### PR TITLE
Fix J1939 CAN ID handling

### DIFF
--- a/src/components/cansignaldata/cansignaldata_p.cpp
+++ b/src/components/cansignaldata/cansignaldata_p.cpp
@@ -231,7 +231,15 @@ void CanSignalDataPrivate::loadDbc(const std::string& filename)
         return;
     }
 
-    _messages = parser.getDb().messages;
+    // Make sure that ID passed to components is 29 bit long
+    // DBC for SAE J1939 seems to have 32nd bit of ID always set
+    _messages.clear();
+    for (auto msg : parser.getDb().messages) {
+        auto canMsg = msg.first;
+        canMsg.id = canMsg.id & 0x1fffffff;
+
+        _messages[canMsg] = msg.second;
+    }
 
     cds_info("CAN DB load successful. {} records found", _messages.size());
 


### PR DESCRIPTION
As reported in #198 there is a problem with handling SAE J1939 compliant DBCs. DBC for J1939 seems to have 32nd bit of CAN ID always set. Make sure that ID passed to components is always 29 bit long.

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@gmail.com>