### PR TITLE
signal{encoder/decoder}: fix byte order & size calculation

### DIFF
--- a/src/components/cansignaldecoder/cansignaldecoder_p.cpp
+++ b/src/components/cansignaldecoder/cansignaldecoder_p.cpp
@@ -1,6 +1,24 @@
 #include "cansignaldecoder_p.h"
 #include <QCanBusFrame>
+#include <array>
 #include <log.h>
+
+// for len in range(1,65):
+//    print('%3d, ' %  ((int((len - 1)/ 8) * 2 + 1)*8 - len), end='')
+//    if len % 8 == 0:
+//        print('')
+// clang-format off
+const std::array beTransTable = {
+      7,  6,  5,  4,  3,  2,  1,  0,
+     15, 14, 13, 12, 11, 10,  9,  8,
+     23, 22, 21, 20, 19, 18, 17, 16,
+     31, 30, 29, 28, 27, 26, 25, 24,
+     39, 38, 37, 36, 35, 34, 33, 32,
+     47, 46, 45, 44, 43, 42, 41, 40,
+     55, 54, 53, 52, 51, 50, 49, 48,
+     63, 62, 61, 60, 59, 58, 57, 56 
+};
+// clang-format on
 
 CanSignalDecoderPrivate::CanSignalDecoderPrivate(CanSignalDecoder* q, CanSignalDecoderCtx&& ctx)
     : _ctx(std::move(ctx))
@@ -77,26 +95,29 @@ void CanSignalDecoderPrivate::decodeFrame(const QCanBusFrame& frame, Direction c
                 continue;
             }
 
-            if (sig.startBit >= (frame.payload().size() * 8)) {
-                bool error = false;
-                if (littleEndian && ((sig.startBit + sig.signalSize - 1) >= (frame.payload().size() * 8))) {
-                    error = true;
-                } else if (!littleEndian && ((sig.startBit - sig.signalSize + 1) < 0)) {
-                    error = true;
-                }
+            // Calculate how many bits is used already before this signal. Calculations are different for
+            // little and big endian. Good overview on how big endian signals are alinged can be found
+            // here: https://github.com/eerimoq/cantools#the-dump-subcommand
+            uint8_t bitsBefore = 0;
 
-                if (error) {
-                    cds_error("Invalid message size - startBit {}, sigSize {}, payload size {}, calc: {}", sig.startBit,
-                                sig.signalSize, frame.payload().size(), frame.payload().size() * 8);
-                    continue;
-                }
+            if (littleEndian) {
+                bitsBefore = sig.startBit;
+            } else {
+                // bitsBefore = 7 - (sig.startBit % 8) + (sig.startBit / 8) * 8;
+                bitsBefore = beTransTable[sig.startBit];
+            }
+
+            if (bitsBefore + sig.signalSize > (frame.payload().size() * 8)) {
+                cds_error(
+                    "Invalid message size - startBit {}, sigSize {}, bitsBefore {}, payload size {}, littleEndian: {}",
+                    sig.startBit, sig.signalSize, frame.payload().size(), littleEndian);
+                continue;
             }
 
             int64_t value = rawToSignal((const uint8_t*)frame.payload().constData(), sig.startBit, sig.signalSize,
                 littleEndian, sig.valueSigned);
 
             QVariant sigVal;
-
 
             if ((std::fmod(sig.factor, 1) == 0.0) && (std::fmod(sig.offset, 1) == 0.0)) {
                 // resulting number will be integer
@@ -129,17 +150,49 @@ int64_t CanSignalDecoderPrivate::rawToSignal(
 {
     int64_t result = 0;
 
-    int bit = startBit;
-    for (int bitpos = 0; bitpos < sigSize; bitpos++) {
-        if (data[bit / 8] & (1 << (bit % 8))) {
-            if (littleEndian) {
-                result |= (1ULL << bitpos);
-            } else {
-                result |= (1ULL << (sigSize - bitpos - 1));
-            }
-        }
+    if (littleEndian) {
+        // Little endian signal example with start bit 2 and length 9 (0=LSB, 8=MSB):
+        // Byte:       0        1        2        3
+        //       +--------+--------+--------+--- - -
+        //       |543210| |    |876|        |
+        //       +--------+--------+--------+--- - -
+        // Bit:   7      0 15     8 23    16 31
+        //
+        // Source: https://github.com/eerimoq/cantools/blob/master/cantools/database/can/signal.py
 
-        bit++;
+        uint8_t bit = startBit;
+        for (uint8_t bitpos = 0; bitpos < sigSize; bitpos++) {
+
+            if (data[bit / 8] & (1 << (bit % 8))) {
+                result |= (1ULL << bitpos);
+            }
+
+            ++bit;
+        }
+    } else {
+
+        // Big endian signal example with start bit 2 and length 5 (0=LSB, 4=MSB):
+        // Byte:       0        1        2        3
+        //        +--------+--------+--------+--- - -
+        //        |    |432|10|     |        |
+        //        +--------+--------+--------+--- - -
+        // Bit:    7      0 15     8 23    16 31
+        //
+        // Source: https://github.com/eerimoq/cantools/blob/master/cantools/database/can/signal.py
+
+        uint8_t bitpos = 0;
+        for (int i = sigSize - 1; i >= 0; --i) {
+            // Fist beTransTable returns number of bytes used before startBit
+            // Then we are adding length of the signal and getting 'offset' where the LSB is
+            // Second 'translation' of 'offset' with beTransTable gives us actual bit position
+            int bit = beTransTable[beTransTable[startBit] + i];
+
+            if (data[bit / 8] & (1 << (bit % 8))) {
+                result |= (1ULL << bitpos);
+            }
+
+            ++bitpos;
+        }
     }
 
     // if signal is signed and sign bit (MSB) is set make sure

--- a/src/components/cansignaldecoder/cansignaldecoder_p.cpp
+++ b/src/components/cansignaldecoder/cansignaldecoder_p.cpp
@@ -103,14 +103,13 @@ void CanSignalDecoderPrivate::decodeFrame(const QCanBusFrame& frame, Direction c
             if (littleEndian) {
                 bitsBefore = sig.startBit;
             } else {
-                // bitsBefore = 7 - (sig.startBit % 8) + (sig.startBit / 8) * 8;
                 bitsBefore = beTransTable[sig.startBit];
             }
 
             if (bitsBefore + sig.signalSize > (frame.payload().size() * 8)) {
                 cds_error(
                     "Invalid message size - startBit {}, sigSize {}, bitsBefore {}, payload size {}, littleEndian: {}",
-                    sig.startBit, sig.signalSize, frame.payload().size(), littleEndian);
+                    sig.startBit, sig.signalSize, bitsBefore, frame.payload().size(), littleEndian);
                 continue;
             }
 

--- a/src/components/cansignaldecoder/cansignaldecoder_p.cpp
+++ b/src/components/cansignaldecoder/cansignaldecoder_p.cpp
@@ -3,11 +3,18 @@
 #include <array>
 #include <log.h>
 
-// for len in range(1,65):
-//    print('%3d, ' %  ((int((len - 1)/ 8) * 2 + 1)*8 - len), end='')
-//    if len % 8 == 0:
-//        print('')
+// Python script used to generate below:
+//
+// for rows in range (1,9):
+//    bit = rows*8 - 1
+//    for cols in range(0,8):
+//        val = int(bit - cols)
+//        print('%3d,' % val, end='')
+//        if val % 8 == 0:
+//            print('')
+//
 // clang-format off
+namespace {
 const std::array beTransTable = {
       7,  6,  5,  4,  3,  2,  1,  0,
      15, 14, 13, 12, 11, 10,  9,  8,
@@ -18,6 +25,7 @@ const std::array beTransTable = {
      55, 54, 53, 52, 51, 50, 49, 48,
      63, 62, 61, 60, 59, 58, 57, 56 
 };
+}
 // clang-format on
 
 CanSignalDecoderPrivate::CanSignalDecoderPrivate(CanSignalDecoder* q, CanSignalDecoderCtx&& ctx)
@@ -95,8 +103,8 @@ void CanSignalDecoderPrivate::decodeFrame(const QCanBusFrame& frame, Direction c
                 continue;
             }
 
-            // Calculate how many bits is used already before this signal. Calculations are different for
-            // little and big endian. Good overview on how big endian signals are alinged can be found
+            // Calculate how many bits are used already before this signal. Calculations are different for
+            // little and big endian. Good overview on how big endian signals are aligned can be found
             // here: https://github.com/eerimoq/cantools#the-dump-subcommand
             uint8_t bitsBefore = 0;
 
@@ -181,7 +189,7 @@ int64_t CanSignalDecoderPrivate::rawToSignal(
 
         uint8_t bitpos = 0;
         for (int i = sigSize - 1; i >= 0; --i) {
-            // Fist beTransTable returns number of bytes used before startBit
+            // First beTransTable returns number of bytes used before startBit
             // Then we are adding length of the signal and getting 'offset' where the LSB is
             // Second 'translation' of 'offset' with beTransTable gives us actual bit position
             int bit = beTransTable[beTransTable[startBit] + i];

--- a/src/components/cansignaldecoder/tests/cansignaldecoder_test.cpp
+++ b/src/components/cansignaldecoder/tests/cansignaldecoder_test.cpp
@@ -354,7 +354,7 @@ TEST_CASE("UnsignedSignals_BE", "[cansignaldecoder]")
     data.startSimulation();
     c.startSimulation();
 
-    QByteArray p = QByteArray::fromHex("2542100808104080");
+    QByteArray p = QByteArray::fromHex("a442081010080201");
 
     QCanBusFrame frame;
     frame.setFrameId(0x1002);
@@ -393,7 +393,7 @@ TEST_CASE("UnsignedSignals_BE", "[cansignaldecoder]")
     c.startSimulation();
     sigSndSpy.clear();
 
-    p = QByteArray::fromHex("4b84201010208000");
+    p = QByteArray::fromHex("d221040808040100");
 
     frame.setFrameId(0x1002);
     frame.setPayload(p);
@@ -444,7 +444,7 @@ TEST_CASE("SignedSignals_BE", "[cansignaldecoder]")
     data.startSimulation();
     c.startSimulation();
 
-    QByteArray p = QByteArray::fromHex("dabdeff7f7efbfff");
+    QByteArray p = QByteArray::fromHex("5bbdf7efeff7fdff");
 
     QCanBusFrame frame;
     frame.setFrameId(0x1003);
@@ -517,7 +517,7 @@ TEST_CASE("SignedSignals_BE", "[cansignaldecoder]")
     c.startSimulation();
     sigSndSpy.clear();
 
-    p = QByteArray::fromHex("3763180c0c186080");
+    p = QByteArray::fromHex("ecc6183030180601");
 
     frame.setFrameId(0x1003);
     frame.setPayload(p);
@@ -553,7 +553,7 @@ TEST_CASE("SignedSignals_BE", "[cansignaldecoder]")
     c.startSimulation();
     sigSndSpy.clear();
 
-    p = QByteArray::fromHex("2542100808104000");
+    p = QByteArray::fromHex("a442081010080200");
 
     frame.setFrameId(0x1003);
     frame.setPayload(p);

--- a/src/components/cansignaldecoder/tests/dbc/tesla_can.dbc
+++ b/src/components/cansignaldecoder/tests/dbc/tesla_can.dbc
@@ -61,31 +61,6 @@ VAL_TABLE_ DI_state 4 "DI_STATE_ENABLE" 3 "DI_STATE_FAULT" 2 "DI_STATE_CLEAR_FAU
 VAL_TABLE_ DI_velocityEstimatorState 4 "VE_STATE_BACKUP_MOTOR" 3 "VE_STATE_BACKUP_WHEELS_B" 2 "VE_STATE_BACKUP_WHEELS_A" 1 "VE_STATE_WHEELS_NORMAL" 0 "VE_STATE_NOT_INITIALIZED" ;
 
 BO_ 4096 UnsignedSignals_LE: 8 TEST
- SG_ Test01 : 0|1@0+ (1,0) [0|0] "" TEST
- SG_ Test02 : 1|2@0+ (1,0) [0|0] "" TEST
- SG_ Test03 : 3|3@0+ (1,0) [0|0] "" TEST
- SG_ Test04 : 6|4@0+ (1,0) [0|0] "" TEST
- SG_ Test05 : 10|5@0+ (1,0) [0|0] "" TEST
- SG_ Test06 : 15|6@0+ (1,0) [0|0] "" TEST
- SG_ Test07 : 21|7@0+ (1,0) [0|0] "" TEST
- SG_ Test08 : 28|8@0+ (1,0) [0|0] "" TEST
- SG_ Test09 : 36|9@0+ (1,0) [0|0] "" TEST
- SG_ Test10 : 45|10@0+ (1,0) [0|0] "" TEST
- SG_ Test11 : 55|9@0+ (1,0) [0|0] "" TEST
-
-BO_ 4097 SignedSignals_LE: 8 TEST
- SG_ Test02 : 0|2@0- (1,0) [0|0] "" TEST
- SG_ Test03 : 2|3@0- (1,0) [0|0] "" TEST
- SG_ Test04 : 5|4@0- (1,0) [0|0] "" TEST
- SG_ Test05 : 9|5@0- (1,0) [0|0] "" TEST
- SG_ Test06 : 14|6@0- (1,0) [0|0] "" TEST
- SG_ Test07 : 20|7@0- (1,0) [0|0] "" TEST
- SG_ Test08 : 27|8@0- (1,0) [0|0] "" TEST
- SG_ Test09 : 35|9@0- (1,0) [0|0] "" TEST
- SG_ Test10 : 44|10@0- (1,0) [0|0] "" TEST
- SG_ Test11 : 54|10@0- (1,0) [0|0] "" TEST
-
-BO_ 4098 UnsignedSignals_BE: 8 TEST
  SG_ Test01 : 0|1@1+ (1,0) [0|0] "" TEST
  SG_ Test02 : 1|2@1+ (1,0) [0|0] "" TEST
  SG_ Test03 : 3|3@1+ (1,0) [0|0] "" TEST
@@ -98,7 +73,7 @@ BO_ 4098 UnsignedSignals_BE: 8 TEST
  SG_ Test10 : 45|10@1+ (1,0) [0|0] "" TEST
  SG_ Test11 : 55|9@1+ (1,0) [0|0] "" TEST
 
-BO_ 4099 SignedSignals_BE: 8 TEST
+BO_ 4097 SignedSignals_LE: 8 TEST
  SG_ Test02 : 0|2@1- (1,0) [0|0] "" TEST
  SG_ Test03 : 2|3@1- (1,0) [0|0] "" TEST
  SG_ Test04 : 5|4@1- (1,0) [0|0] "" TEST
@@ -110,11 +85,36 @@ BO_ 4099 SignedSignals_BE: 8 TEST
  SG_ Test10 : 44|10@1- (1,0) [0|0] "" TEST
  SG_ Test11 : 54|10@1- (1,0) [0|0] "" TEST
 
+BO_ 4098 UnsignedSignals_BE: 8 TEST
+ SG_ Test01 : 7|1@0+ (1,0) [0|0] "" TEST
+ SG_ Test02 : 6|2@0+ (1,0) [0|0] "" TEST
+ SG_ Test03 : 4|3@0+ (1,0) [0|0] "" TEST
+ SG_ Test04 : 1|4@0+ (1,0) [0|0] "" TEST
+ SG_ Test05 : 13|5@0+ (1,0) [0|0] "" TEST
+ SG_ Test06 : 8|6@0+ (1,0) [0|0] "" TEST
+ SG_ Test07 : 18|7@0+ (1,0) [0|0] "" TEST
+ SG_ Test08 : 27|8@0+ (1,0) [0|0] "" TEST
+ SG_ Test09 : 35|9@0+ (1,0) [0|0] "" TEST
+ SG_ Test10 : 42|10@0+ (1,0) [0|0] "" TEST
+ SG_ Test11 : 48|9@0+ (1,0) [0|0] "" TEST
+
+BO_ 4099 SignedSignals_BE: 8 TEST
+ SG_ Test02 : 7|2@0- (1,0) [0|0] "" TEST
+ SG_ Test03 : 5|3@0- (1,0) [0|0] "" TEST
+ SG_ Test04 : 2|4@0- (1,0) [0|0] "" TEST
+ SG_ Test05 : 14|5@0- (1,0) [0|0] "" TEST
+ SG_ Test06 : 9|6@0- (1,0) [0|0] "" TEST
+ SG_ Test07 : 19|7@0- (1,0) [0|0] "" TEST
+ SG_ Test08 : 28|8@0- (1,0) [0|0] "" TEST
+ SG_ Test09 : 36|9@0- (1,0) [0|0] "" TEST
+ SG_ Test10 : 43|10@0- (1,0) [0|0] "" TEST
+ SG_ Test11 : 49|10@0- (1,0) [0|0] "" TEST
+
 BO_ 1160 DAS_steeringControl: 4 NEO
- SG_ DAS_steeringControlType : 23|80@0+ (0,0) [0|0] "" EPAS
- SG_ DAS_steeringControlChecksum : 31|80@0+ (1,0) [0|0] "" EPAS
- SG_ DAS_steeringControlCounter : 19|80@0+ (1,0) [0|0] "" EPAS
- SG_ DAS_steeringAngleRequest : 6|80@0+ (0.1,-1638.35) [-1638.35|1638.35] "deg" EPAS
+ SG_ DAS_steeringControlType : 23|80@1+ (0,0) [0|0] "" EPAS
+ SG_ DAS_steeringControlChecksum : 31|80@1+ (1,0) [0|0] "" EPAS
+ SG_ DAS_steeringControlCounter : 19|80@1+ (1,0) [0|0] "" EPAS
+ SG_ DAS_steeringAngleRequest : 6|80@1+ (0.1,-1638.35) [-1638.35|1638.35] "deg" EPAS
  SG_ DAS_steeringHapticRequest : 7|80@2+ (1,0) [0|0] "" EPAS
  
 BO_ 257 GTW_epasControl: 3 NEO

--- a/src/components/cansignalencoder/cansignalencoder_p.cpp
+++ b/src/components/cansignalencoder/cansignalencoder_p.cpp
@@ -2,6 +2,31 @@
 #include <QCanBusFrame>
 #include <log.h>
 
+// Python script used to generate below:
+//
+// for rows in range (1,9):
+//    bit = rows*8 - 1
+//    for cols in range(0,8):
+//        val = int(bit - cols)
+//        print('%3d,' % val, end='')
+//        if val % 8 == 0:
+//            print('')
+//
+// clang-format off
+namespace {
+const std::array beTransTable = {
+      7,  6,  5,  4,  3,  2,  1,  0,
+     15, 14, 13, 12, 11, 10,  9,  8,
+     23, 22, 21, 20, 19, 18, 17, 16,
+     31, 30, 29, 28, 27, 26, 25, 24,
+     39, 38, 37, 36, 35, 34, 33, 32,
+     47, 46, 45, 44, 43, 42, 41, 40,
+     55, 54, 53, 52, 51, 50, 49, 48,
+     63, 62, 61, 60, 59, 58, 57, 56
+};
+}
+// clang-format on
+
 CanSignalEncoderPrivate::CanSignalEncoderPrivate(CanSignalEncoder* q, CanSignalEncoderCtx&& ctx)
     : _ctx(std::move(ctx))
     , q_ptr(q)
@@ -81,17 +106,26 @@ void CanSignalEncoderPrivate::encodeSignal(const QString& name, const QVariant& 
                 _rawCache[id].fill(0, msgDesc->first.dlc);
             }
 
-            bool error = false;
+            // Calculate how many bits are used already before this signal. Calculations are different for
+            // little and big endian. Good overview on how big endian signals are aligned can be found
+            // here: https://github.com/eerimoq/cantools#the-dump-subcommand
+            uint8_t bitsBefore = 0;
             bool littleEndian = sig.byteOrder == 1;
-            if (littleEndian && ((sig.startBit + sig.signalSize - 1) >= (_rawCache[id].size() * 8))) {
-                error = true;
-            } else if (!littleEndian && ((sig.startBit - sig.signalSize + 1) < 0)) {
-                error = true;
+            uint8_t msgSize = _rawCache[id].size();
+
+            if (littleEndian) {
+                bitsBefore = sig.startBit;
+            } else {
+                bitsBefore = beTransTable[sig.startBit];
             }
-            if (error) {
-                cds_error("Payload size LE: {} ('{}') for signal '{}' is too small. StartBit {}, signalSize {}", littleEndian, _rawCache[id].size() * 8, sig.signal_name, sig.startBit, sig.signalSize);
+
+            if (bitsBefore + sig.signalSize > (msgSize * 8)) {
+                cds_error("Invalid signal or message size - startBit {}, sigSize {}, bitsBefore {}, payload size {}, "
+                          "littleEndian: {}",
+                    sig.startBit, sig.signalSize, bitsBefore, msgSize, littleEndian);
                 continue;
             }
+
             signalToRaw(id, sig, val, msgDesc->first.updateCycle);
             return;
         }
@@ -114,18 +148,41 @@ void CanSignalEncoderPrivate::signalToRaw(
     uint8_t* data = (uint8_t*)_rawCache[id].data();
 
     if (sigDesc.byteOrder == 0) {
-        // motorola / big endian mode
-        auto bit = sigDesc.startBit;
-        for (int bitpos = 0; bitpos < sigDesc.signalSize; bitpos++) {
+
+        // Motorola / Big endian signal example with start bit 2 and length 5 (0=LSB, 4=MSB):
+        // Byte:       0        1        2        3
+        //        +--------+--------+--------+--- - -
+        //        |    |432|10|     |        |
+        //        +--------+--------+--------+--- - -
+        // Bit:    7      0 15     8 23    16 31
+        //
+        // Source: https://github.com/eerimoq/cantools/blob/master/cantools/database/can/signal.py
+
+        uint8_t bitpos = 0;
+        for (int i = sigDesc.signalSize - 1; i >= 0; --i) {
+            // First beTransTable returns number of bytes used before startBit
+            // Then we are adding length of the signal and getting 'offset' where the LSB is
+            // Second 'translation' of 'offset' with beTransTable gives us actual bit position
+            int bit = beTransTable[beTransTable[sigDesc.startBit] + i];
+
             // clear bit first
             data[bit / 8] &= ~(1U << (bit % 8));
             // set bit
-            data[bit / 8] |= ((rawVal >> (sigDesc.signalSize - bitpos - 1)) & 1U) << (bit % 8);
+            data[bit / 8] |= ((rawVal >> bitpos) & 1U) << (bit % 8);
 
-            bit++;
+            ++bitpos;
         }
     } else {
-        // little endian
+
+        // Little endian signal example with start bit 2 and length 9 (0=LSB, 8=MSB):
+        // Byte:       0        1        2        3
+        //       +--------+--------+--------+--- - -
+        //       |543210| |    |876|        |
+        //       +--------+--------+--------+--- - -
+        // Bit:   7      0 15     8 23    16 31
+        //
+        // Source: https://github.com/eerimoq/cantools/blob/master/cantools/database/can/signal.py
+
         auto bit = sigDesc.startBit;
         for (int bitpos = 0; bitpos < sigDesc.signalSize; bitpos++) {
             // clear bit first
@@ -179,5 +236,4 @@ void CanSignalEncoderPrivate::initCacheAndTimers()
                 msg.first.initValue);
         }
     }
-
 }

--- a/src/components/cansignalencoder/tests/cansignalencoder_test.cpp
+++ b/src/components/cansignalencoder/tests/cansignalencoder_test.cpp
@@ -610,17 +610,14 @@ TEST_CASE("UnsignedSignals_BE", "[cansignalencoder]")
     REQUIRE(frame.frameId() == 0x1002);
     REQUIRE(frame.hasExtendedFrameFormat() == true);
 
-    //  1000 0000 0100 0000 0001 0000 0000 1000
-    //  0000 1000 0001 0000 0100 0010 0010 0101
-
-    REQUIRE(frame.payload()[0] == (char)0x25);
+    REQUIRE(frame.payload()[0] == (char)0xa4);
     REQUIRE(frame.payload()[1] == (char)0x42);
-    REQUIRE(frame.payload()[2] == (char)0x10);
-    REQUIRE(frame.payload()[3] == (char)0x08);
-    REQUIRE(frame.payload()[4] == (char)0x08);
-    REQUIRE(frame.payload()[5] == (char)0x10);
-    REQUIRE(frame.payload()[6] == (char)0x40);
-    REQUIRE(frame.payload()[7] == (char)0x80);
+    REQUIRE(frame.payload()[2] == (char)0x08);
+    REQUIRE(frame.payload()[3] == (char)0x10);
+    REQUIRE(frame.payload()[4] == (char)0x10);
+    REQUIRE(frame.payload()[5] == (char)0x08);
+    REQUIRE(frame.payload()[6] == (char)0x02);
+    REQUIRE(frame.payload()[7] == (char)0x01);
 
     sigSndSpy.clear();
 
@@ -643,16 +640,13 @@ TEST_CASE("UnsignedSignals_BE", "[cansignalencoder]")
     REQUIRE(frame.frameId() == 0x1002);
     REQUIRE(frame.hasExtendedFrameFormat() == true);
 
-    //  0000 0000 1000 0000 0010 0000 0001 0000
-    //  0001 0000 0010 0000 1000 0100 0100 1011
-
-    REQUIRE(frame.payload()[0] == (char)0x4b);
-    REQUIRE(frame.payload()[1] == (char)0x84);
-    REQUIRE(frame.payload()[2] == (char)0x20);
-    REQUIRE(frame.payload()[3] == (char)0x10);
-    REQUIRE(frame.payload()[4] == (char)0x10);
-    REQUIRE(frame.payload()[5] == (char)0x20);
-    REQUIRE(frame.payload()[6] == (char)0x80);
+    REQUIRE(frame.payload()[0] == (char)0xd2);
+    REQUIRE(frame.payload()[1] == (char)0x21);
+    REQUIRE(frame.payload()[2] == (char)0x04);
+    REQUIRE(frame.payload()[3] == (char)0x08);
+    REQUIRE(frame.payload()[4] == (char)0x08);
+    REQUIRE(frame.payload()[5] == (char)0x04);
+    REQUIRE(frame.payload()[6] == (char)0x01);
     REQUIRE(frame.payload()[7] == (char)0x00);
 }
 
@@ -692,16 +686,13 @@ TEST_CASE("SignedSignals_BE", "[cansignalencoder]")
     REQUIRE(frame.frameId() == 0x1003);
     REQUIRE(frame.hasExtendedFrameFormat() == true);
 
-    //  1111 1111 1011 1111 1110 1111 1111 0111
-    //  1111 0111 1110 1111 1011 1101 1101 1010
-
-    REQUIRE(frame.payload()[0] == (char)0xda);
+    REQUIRE(frame.payload()[0] == (char)0x5b);
     REQUIRE(frame.payload()[1] == (char)0xbd);
-    REQUIRE(frame.payload()[2] == (char)0xef);
-    REQUIRE(frame.payload()[3] == (char)0xf7);
-    REQUIRE(frame.payload()[4] == (char)0xf7);
-    REQUIRE(frame.payload()[5] == (char)0xef);
-    REQUIRE(frame.payload()[6] == (char)0xbf);
+    REQUIRE(frame.payload()[2] == (char)0xf7);
+    REQUIRE(frame.payload()[3] == (char)0xef);
+    REQUIRE(frame.payload()[4] == (char)0xef);
+    REQUIRE(frame.payload()[5] == (char)0xf7);
+    REQUIRE(frame.payload()[6] == (char)0xfd);
     REQUIRE(frame.payload()[7] == (char)0xff);
 
     sigSndSpy.clear();
@@ -723,9 +714,6 @@ TEST_CASE("SignedSignals_BE", "[cansignalencoder]")
 
     REQUIRE(frame.frameId() == 0x1003);
     REQUIRE(frame.hasExtendedFrameFormat() == true);
-
-    //  1111 1111 1111 1111 1111 1111 1111 1111
-    //  1111 1111 1111 1111 1111 1111 1111 1111
 
     REQUIRE(frame.payload()[0] == (char)0xff);
     REQUIRE(frame.payload()[1] == (char)0xff);
@@ -756,18 +744,15 @@ TEST_CASE("SignedSignals_BE", "[cansignalencoder]")
     REQUIRE(frame.frameId() == 0x1003);
     REQUIRE(frame.hasExtendedFrameFormat() == true);
 
-    //  1000 0000 0110 0000 0001 1000 0000 1100
-    //  0000 1100 0001 1000 0110 0011 0011 0111
-
-    REQUIRE(frame.payload()[0] == (char)0x37);
-    REQUIRE(frame.payload()[1] == (char)0x63);
+    REQUIRE(frame.payload()[0] == (char)0xec);
+    REQUIRE(frame.payload()[1] == (char)0xc6);
     REQUIRE(frame.payload()[2] == (char)0x18);
-    REQUIRE(frame.payload()[3] == (char)0x0c);
-    REQUIRE(frame.payload()[4] == (char)0x0c);
+    REQUIRE(frame.payload()[3] == (char)0x30);
+    REQUIRE(frame.payload()[4] == (char)0x30);
     REQUIRE(frame.payload()[5] == (char)0x18);
-    REQUIRE(frame.payload()[6] == (char)0x60);
-    REQUIRE(frame.payload()[7] == (char)0x80);
-
+    REQUIRE(frame.payload()[6] == (char)0x06);
+    REQUIRE(frame.payload()[7] == (char)0x01);
+    
     sigSndSpy.clear();
 
     c.rcvSignal("0x1003_Test02", -2);
@@ -788,16 +773,13 @@ TEST_CASE("SignedSignals_BE", "[cansignalencoder]")
     REQUIRE(frame.frameId() == 0x1003);
     REQUIRE(frame.hasExtendedFrameFormat() == true);
 
-    //  0000 0000 0100 0000 0001 0000 0000 1000
-    //  0000 1000 0001 0000 0100 0010 0010 0101
-
-    REQUIRE(frame.payload()[0] == (char)0x25);
+    REQUIRE(frame.payload()[0] == (char)0xa4);
     REQUIRE(frame.payload()[1] == (char)0x42);
-    REQUIRE(frame.payload()[2] == (char)0x10);
-    REQUIRE(frame.payload()[3] == (char)0x08);
-    REQUIRE(frame.payload()[4] == (char)0x08);
-    REQUIRE(frame.payload()[5] == (char)0x10);
-    REQUIRE(frame.payload()[6] == (char)0x40);
+    REQUIRE(frame.payload()[2] == (char)0x08);
+    REQUIRE(frame.payload()[3] == (char)0x10);
+    REQUIRE(frame.payload()[4] == (char)0x10);
+    REQUIRE(frame.payload()[5] == (char)0x08);
+    REQUIRE(frame.payload()[6] == (char)0x02);
     REQUIRE(frame.payload()[7] == (char)0x00);
 }
 

--- a/src/components/cansignalencoder/tests/dbc/tesla_can.dbc
+++ b/src/components/cansignalencoder/tests/dbc/tesla_can.dbc
@@ -61,31 +61,6 @@ VAL_TABLE_ DI_state 4 "DI_STATE_ENABLE" 3 "DI_STATE_FAULT" 2 "DI_STATE_CLEAR_FAU
 VAL_TABLE_ DI_velocityEstimatorState 4 "VE_STATE_BACKUP_MOTOR" 3 "VE_STATE_BACKUP_WHEELS_B" 2 "VE_STATE_BACKUP_WHEELS_A" 1 "VE_STATE_WHEELS_NORMAL" 0 "VE_STATE_NOT_INITIALIZED" ;
 
 BO_ 4096 UnsignedSignals_LE: 8 TEST
- SG_ Test01 : 0|1@0+ (1,0) [0|0] "" TEST
- SG_ Test02 : 1|2@0+ (1,0) [0|0] "" TEST
- SG_ Test03 : 3|3@0+ (1,0) [0|0] "" TEST
- SG_ Test04 : 6|4@0+ (1,0) [0|0] "" TEST
- SG_ Test05 : 10|5@0+ (1,0) [0|0] "" TEST
- SG_ Test06 : 15|6@0+ (1,0) [0|0] "" TEST
- SG_ Test07 : 21|7@0+ (1,0) [0|0] "" TEST
- SG_ Test08 : 28|8@0+ (1,0) [0|0] "" TEST
- SG_ Test09 : 36|9@0+ (1,0) [0|0] "" TEST
- SG_ Test10 : 45|10@0+ (1,0) [0|0] "" TEST
- SG_ Test11 : 55|9@0+ (1,0) [0|0] "" TEST
-
-BO_ 4097 SignedSignals_LE: 8 TEST
- SG_ Test02 : 0|2@0- (1,0) [0|0] "" TEST
- SG_ Test03 : 2|3@0- (1,0) [0|0] "" TEST
- SG_ Test04 : 5|4@0- (1,0) [0|0] "" TEST
- SG_ Test05 : 9|5@0- (1,0) [0|0] "" TEST
- SG_ Test06 : 14|6@0- (1,0) [0|0] "" TEST
- SG_ Test07 : 20|7@0- (1,0) [0|0] "" TEST
- SG_ Test08 : 27|8@0- (1,0) [0|0] "" TEST
- SG_ Test09 : 35|9@0- (1,0) [0|0] "" TEST
- SG_ Test10 : 44|10@0- (1,0) [0|0] "" TEST
- SG_ Test11 : 54|10@0- (1,0) [0|0] "" TEST
-
-BO_ 4098 UnsignedSignals_BE: 8 TEST
  SG_ Test01 : 0|1@1+ (1,0) [0|0] "" TEST
  SG_ Test02 : 1|2@1+ (1,0) [0|0] "" TEST
  SG_ Test03 : 3|3@1+ (1,0) [0|0] "" TEST
@@ -98,7 +73,7 @@ BO_ 4098 UnsignedSignals_BE: 8 TEST
  SG_ Test10 : 45|10@1+ (1,0) [0|0] "" TEST
  SG_ Test11 : 55|9@1+ (1,0) [0|0] "" TEST
 
-BO_ 4099 SignedSignals_BE: 8 TEST
+BO_ 4097 SignedSignals_LE: 8 TEST
  SG_ Test02 : 0|2@1- (1,0) [0|0] "" TEST
  SG_ Test03 : 2|3@1- (1,0) [0|0] "" TEST
  SG_ Test04 : 5|4@1- (1,0) [0|0] "" TEST
@@ -109,6 +84,31 @@ BO_ 4099 SignedSignals_BE: 8 TEST
  SG_ Test09 : 35|9@1- (1,0) [0|0] "" TEST
  SG_ Test10 : 44|10@1- (1,0) [0|0] "" TEST
  SG_ Test11 : 54|10@1- (1,0) [0|0] "" TEST
+
+BO_ 4098 UnsignedSignals_BE: 8 TEST
+ SG_ Test01 : 7|1@0+ (1,0) [0|0] "" TEST
+ SG_ Test02 : 6|2@0+ (1,0) [0|0] "" TEST
+ SG_ Test03 : 4|3@0+ (1,0) [0|0] "" TEST
+ SG_ Test04 : 1|4@0+ (1,0) [0|0] "" TEST
+ SG_ Test05 : 13|5@0+ (1,0) [0|0] "" TEST
+ SG_ Test06 : 8|6@0+ (1,0) [0|0] "" TEST
+ SG_ Test07 : 18|7@0+ (1,0) [0|0] "" TEST
+ SG_ Test08 : 27|8@0+ (1,0) [0|0] "" TEST
+ SG_ Test09 : 35|9@0+ (1,0) [0|0] "" TEST
+ SG_ Test10 : 42|10@0+ (1,0) [0|0] "" TEST
+ SG_ Test11 : 48|9@0+ (1,0) [0|0] "" TEST
+
+BO_ 4099 SignedSignals_BE: 8 TEST
+ SG_ Test02 : 7|2@0- (1,0) [0|0] "" TEST
+ SG_ Test03 : 5|3@0- (1,0) [0|0] "" TEST
+ SG_ Test04 : 2|4@0- (1,0) [0|0] "" TEST
+ SG_ Test05 : 14|5@0- (1,0) [0|0] "" TEST
+ SG_ Test06 : 9|6@0- (1,0) [0|0] "" TEST
+ SG_ Test07 : 19|7@0- (1,0) [0|0] "" TEST
+ SG_ Test08 : 28|8@0- (1,0) [0|0] "" TEST
+ SG_ Test09 : 36|9@0- (1,0) [0|0] "" TEST
+ SG_ Test10 : 43|10@0- (1,0) [0|0] "" TEST
+ SG_ Test11 : 49|10@0- (1,0) [0|0] "" TEST
 
 BO_ 1160 DAS_steeringControl: 4 NEO
  SG_ DAS_steeringControlType : 23|2@0+ (0,0) [0|0] "" EPAS


### PR DESCRIPTION
This PR might fix all possible encoding issues, these seem related:

https://github.com/GENIVI/CANdevStudio/issues/202
https://github.com/GENIVI/CANdevStudio/issues/200

The PDF that supposedly describes the DBC format got
the byte-order apparently wrong :)
    
The correct values are:
0 => big-endian, motorola
1 => little-endian, intel

Both encoder/decoder do bound checks before inserting the
 bits into the raw signal. The bound checks need to take the
endianess into account because:
    
if the signal is little_endian / intel, start_bit describes
the LSB, so end_bit = start_bit + signal_size
if the signal is big_endian / motorola, start_bit describes
the MSB, so end_bit = start_bit - signal_size + 1

This I tested this PR together with https://github.com/GENIVI/CANdevStudio/pull/205
To test simply cherry-pick dfe3e9062ce9584a6ee79c9fdaa25da47b4f6b01