### PR TITLE
Fixing CanRawData and CanSignalModel c++ include dependencies

### DIFF
--- a/src/common/datamodeltypes/canrawdata.h
+++ b/src/common/datamodeltypes/canrawdata.h
@@ -1,17 +1,16 @@
 #ifndef __CANRAWDATA_H
 #define __CANRAWDATA_H
 
+#include <nodes/NodeData>
 #include <nodes/NodeDataModel>
 
 #include <QCanBusFrame>
 #include "datadirection.h"
 
-using QtNodes::NodeDataType;
-
 /**
 *   @brief The class describing data model used as output for CanDevice node
 */
-class CanRawData : public NodeData {
+class CanRawData : public QtNodes::NodeData {
 public:
     CanRawData(){};
     CanRawData(QCanBusFrame const& frame, Direction const direction = Direction::TX, bool status = true)
@@ -24,9 +23,9 @@ public:
     *   @brief  Used to get data type id and displayed text for ports
     *   @return NodeDataType of rawview
     */
-    NodeDataType type() const override
+    QtNodes::NodeDataType type() const override
     {
-        return NodeDataType{ "rawframe", "RAW" };
+        return QtNodes::NodeDataType{ "rawframe", "RAW" };
     }
 
     /**

--- a/src/common/datamodeltypes/cansignalmodel.h
+++ b/src/common/datamodeltypes/cansignalmodel.h
@@ -1,10 +1,13 @@
 #ifndef CANSIGNALMODEL_H
 #define CANSIGNALMODEL_H
 
+#include <QVariant>
+#include <nodes/NodeData>
 #include <nodes/NodeDataModel>
+
 #include "datadirection.h"
 
-class CanSignalModel : public NodeData {
+class CanSignalModel : public QtNodes::NodeData {
 public:
     CanSignalModel(){};
     CanSignalModel(const QString& sigName, const QVariant& value, const Direction& dir = Direction::TX)
@@ -14,9 +17,9 @@ public:
     {
     }
 
-    NodeDataType type() const override
+    QtNodes::NodeDataType type() const override
     {
-        return NodeDataType{ "signal", "SIG" };
+        return QtNodes::NodeDataType{ "signal", "SIG" };
     }
     
     QVariant value() const


### PR DESCRIPTION
Fixing include files: use proper interface, remove using keyword from headers, add necessary dependencies