### PR TITLE
Add Kvaser PassThruCAN plugin configuration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ backend: passthrucan
 configuration: BitRateKey = 250000
 interface: CANUSB
 ```
+CanDevice settings example for Kvaser USBcan:
+```
+backend: passthrucan
+configuration: BitRateKey = 250000
+interface: J2534 (kline) for Kvaser Hardware
+```
 ### CANdevStudio without CAN hardware
 CANdevStudio can be used without actual CAN hardware thanks to Linux's built-in emulation.
 #### VCAN


### PR DESCRIPTION
Tested PassThruCAN support for the Kvaser USBcan tools (specifically the USBcan Pro 2xHS v2). "J2534 (kline) for Kvaser Hardware" is used for the interface parameter, obtained from the Windows registry.